### PR TITLE
[FEATURE] Adding computer extension attributes endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 1.0.0.beta.2
+- Adds support for `/computerextensionattributes` endpoint
+- Fixes minor typo in `client.go` causing tests to fail
+## 1.0.0.beta.1
+Initial release of Jamf classic API Go client with support for managing the following:
+- computers
+- scripts
+- policies

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains an unoffical Go API client for Jamf REST API's.
     - [Code Samples](https://www.jamf.com/developers/apis/classic/code-samples/)
   - [Jamf Pro API](https://www.jamf.com/developers/apis/jamf-pro/overview/) **(TBD)**
     - [API Reference](https://www.jamf.com/developers/apis/jamf-pro/reference/)
-    - **Note:** Development on the pro client has not been started, if an work is to be added here please keep in mind that the endpoints are prefaced with `v1` per the API Reference below and therfore the file structure should reflect `/pro/v1/*.go`
+    - **Note:** Development on the pro client has not been started, if any work is to be added here please keep in mind that the endpoints are prefaced with `v1` per the API Reference below and therfore the file structure should reflect `/pro/v1/*.go`
 
 To see what functionality is available in the current API client release, please see the [API Coverage](https://github.com/DataDog/jamf-api-client-go/blob/main/docs/api_coverage.md) doc.
 ## Disclaimers

--- a/classic/client.go
+++ b/classic/client.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	scriptsContext   = "scripts"
-	computersContext = "computers"
-	policiesContext  = "policies"
+	scriptsContext         = "scripts"
+	computersContext       = "computers"
+	computerExtAttrContext = "computerextensionattributes"
+	policiesContext        = "policies"
 )
 
 // Client represents the interface used to communicate with
@@ -43,7 +44,7 @@ func defaultHTTPClient() *http.Client {
 // NewClient returns a new Jamf HTTP client to be used for API requests
 func NewClient(domain string, username string, password string, client *http.Client) (*Client, error) {
 	if domain == "" || username == "" || password == "" {
-		return nil, errors.New("you must provide a valid Jamf domain, username, and passowrd")
+		return nil, errors.New("you must provide a valid Jamf domain, username, and password")
 	}
 
 	if client == nil {

--- a/classic/computer_extenstion_attr.go
+++ b/classic/computer_extenstion_attr.go
@@ -1,0 +1,154 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+package classic
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ComputerExtensionAttrExists is a helper function to check if an extension attribute
+// exists without having to parse the response. Note: If an error occurs that doesn't include
+// a not found message ... we log the error and return false
+func (j *Client) ComputerExtensionAttrExists(identifier interface{}) bool {
+	_, err := j.ComputerExtensionAttributeDetails(identifier)
+	if err != nil {
+		if !strings.Contains(err.Error(), "The server has not found anything matching the request URI") {
+			j.logger.Errorf("did not find computer extension attribute %v due to %s", identifier, err.Error())
+		}
+		return false
+	}
+	return true
+}
+
+// ComputerExtensionAttributes returns all computer extension attributes
+func (j *Client) ComputerExtensionAttributes() (*CompterExtensionAttributes, error) {
+	ep := fmt.Sprintf("%s/%s", j.Endpoint, computerExtAttrContext)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", ep, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error building JAMF computer extension attribute query request")
+	}
+
+	res := &CompterExtensionAttributes{}
+	if err := j.makeAPIrequest(req, &res); err != nil {
+		return nil, errors.Wrapf(err, "unable to query computer extension attribute from %s", ep)
+	}
+	return res, nil
+}
+
+// ComputerExtensionAttributeDetails returns the details for a specific computer extension attribute given its ID or Name
+func (j *Client) ComputerExtensionAttributeDetails(identifier interface{}) (*ComputerExtensionAttributeDetails, error) {
+	ep, err := EndpointBuilder(j.Endpoint, computerExtAttrContext, identifier)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF query request endpoint for script: %v", identifier)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), "GET", ep, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF query request for computer extension attribute: %v", identifier)
+	}
+
+	res := ComputerExtensionAttributeDetails{}
+	if err := j.makeAPIrequest(req, &res); err != nil {
+		return nil, errors.Wrapf(err, "unable to query computer extension attribute with ID: %v from %s", identifier, ep)
+	}
+
+	return &res, nil
+}
+
+// UpdateComputerExtensionAttribue will update a computer extension attribute in Jamf by either ID or Name
+func (j *Client) UpdateComputerExtensionAttribue(identifier interface{}, content *ComputerExtenstionAttribute) (*ComputerExtenstionAttribute, error) {
+	ep, err := EndpointBuilder(j.Endpoint, computerExtAttrContext, identifier)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF query request for computer extension attribute: %v", identifier)
+	}
+
+	err = ValidateComputerExtensionAttribute(content)
+	if err != nil {
+		return nil, errors.Wrapf(err, "computer extension attribute validation failed: %v", identifier)
+	}
+
+	bodyContent, err := xml.Marshal(content)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF update payload for computer extension attribute: %v", identifier)
+	}
+
+	body := bytes.NewReader(bodyContent)
+	req, err := http.NewRequestWithContext(context.Background(), "PUT", ep, body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF update request for computer extension attribute: %v (%s)", identifier, ep)
+	}
+
+	res := ComputerExtenstionAttribute{}
+	if err := j.makeAPIrequest(req, &res); err != nil {
+		return nil, errors.Wrapf(err, "unable to process JAMF update request for computer extension attribute: %v (%s)", identifier, ep)
+	}
+
+	return &res, nil
+}
+
+// CreateComputerExtenstionAttribute will create a computer extension attribute in Jamf
+func (j *Client) CreateComputerExtenstionAttribute(content *ComputerExtenstionAttribute) (*ComputerExtenstionAttribute, error) {
+	// -1 denotes the next available ID
+	ep, err := EndpointBuilder(j.Endpoint, computerExtAttrContext, -1)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF query request for new computer extension attribute")
+	}
+
+	if content == nil {
+		return nil, errors.Wrapf(fmt.Errorf("Empty payload"), "unable to process JAMF creation request for computer extension attribute: (%s)", ep)
+	}
+
+	if content.Name == "" {
+		return nil, errors.Wrapf(fmt.Errorf("Name required for new computer extension attribute"), "unable to process JAMF creation request for computer extension attribute: (%s)", ep)
+	}
+
+	err = ValidateComputerExtensionAttribute(content)
+	if err != nil {
+		return nil, errors.Wrapf(err, "computer extension attribute validation failed: %v", content.Name)
+	}
+
+	bodyContent, err := xml.Marshal(content)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF creation payload for computer extension attribute: %v", content.Name)
+	}
+
+	body := bytes.NewReader(bodyContent)
+	req, err := http.NewRequestWithContext(context.Background(), "POST", ep, body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF creation request for computer extension attribute: %v (%s)", content.Name, ep)
+	}
+
+	res := ComputerExtenstionAttribute{}
+	if err := j.makeAPIrequest(req, &res); err != nil {
+		return nil, errors.Wrapf(err, "unable to process JAMF creation request for computer extension attribute: %v (%s)", content.Name, ep)
+	}
+
+	return &res, nil
+}
+
+// DeleteComputerExtenstionAttribute will delete a computer extension attribute by either ID or Name
+func (j *Client) DeleteComputerExtenstionAttribute(identifier interface{}) (*ComputerExtenstionAttribute, error) {
+	ep, err := EndpointBuilder(j.Endpoint, computerExtAttrContext, identifier)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF query request for computer extension attribute: %v", identifier)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "DELETE", ep, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF deletion request for computer extension attribute: %v (%s)", identifier, ep)
+	}
+
+	res := ComputerExtenstionAttribute{}
+	if err := j.makeAPIrequest(req, &res); err != nil {
+		return nil, errors.Wrapf(err, "unable to process JAMF deletion request for computer extension attribute: %v (%s)", identifier, ep)
+	}
+
+	return &res, nil
+}

--- a/classic/computer_extenstion_attr.go
+++ b/classic/computer_extenstion_attr.go
@@ -29,14 +29,14 @@ func (j *Client) ComputerExtensionAttrExists(identifier interface{}) bool {
 }
 
 // ComputerExtensionAttributes returns all computer extension attributes
-func (j *Client) ComputerExtensionAttributes() (*CompterExtensionAttributes, error) {
+func (j *Client) ComputerExtensionAttributes() (*ComputerExtensionAttributes, error) {
 	ep := fmt.Sprintf("%s/%s", j.Endpoint, computerExtAttrContext)
 	req, err := http.NewRequestWithContext(context.Background(), "GET", ep, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error building JAMF computer extension attribute query request")
 	}
 
-	res := &CompterExtensionAttributes{}
+	res := &ComputerExtensionAttributes{}
 	if err := j.makeAPIrequest(req, &res); err != nil {
 		return nil, errors.Wrapf(err, "unable to query computer extension attribute from %s", ep)
 	}
@@ -63,7 +63,7 @@ func (j *Client) ComputerExtensionAttributeDetails(identifier interface{}) (*Com
 }
 
 // UpdateComputerExtensionAttribue will update a computer extension attribute in Jamf by either ID or Name
-func (j *Client) UpdateComputerExtensionAttribue(identifier interface{}, content *ComputerExtenstionAttribute) (*ComputerExtenstionAttribute, error) {
+func (j *Client) UpdateComputerExtensionAttribue(identifier interface{}, content *ComputerExtensionAttribute) (*ComputerExtensionAttribute, error) {
 	ep, err := EndpointBuilder(j.Endpoint, computerExtAttrContext, identifier)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error building JAMF query request for computer extension attribute: %v", identifier)
@@ -85,7 +85,7 @@ func (j *Client) UpdateComputerExtensionAttribue(identifier interface{}, content
 		return nil, errors.Wrapf(err, "error building JAMF update request for computer extension attribute: %v (%s)", identifier, ep)
 	}
 
-	res := ComputerExtenstionAttribute{}
+	res := ComputerExtensionAttribute{}
 	if err := j.makeAPIrequest(req, &res); err != nil {
 		return nil, errors.Wrapf(err, "unable to process JAMF update request for computer extension attribute: %v (%s)", identifier, ep)
 	}
@@ -93,8 +93,8 @@ func (j *Client) UpdateComputerExtensionAttribue(identifier interface{}, content
 	return &res, nil
 }
 
-// CreateComputerExtenstionAttribute will create a computer extension attribute in Jamf
-func (j *Client) CreateComputerExtenstionAttribute(content *ComputerExtenstionAttribute) (*ComputerExtenstionAttribute, error) {
+// CreateComputerExtensionAttribute will create a computer extension attribute in Jamf
+func (j *Client) CreateComputerExtensionAttribute(content *ComputerExtensionAttribute) (*ComputerExtensionAttribute, error) {
 	// -1 denotes the next available ID
 	ep, err := EndpointBuilder(j.Endpoint, computerExtAttrContext, -1)
 	if err != nil {
@@ -125,7 +125,7 @@ func (j *Client) CreateComputerExtenstionAttribute(content *ComputerExtenstionAt
 		return nil, errors.Wrapf(err, "error building JAMF creation request for computer extension attribute: %v (%s)", content.Name, ep)
 	}
 
-	res := ComputerExtenstionAttribute{}
+	res := ComputerExtensionAttribute{}
 	if err := j.makeAPIrequest(req, &res); err != nil {
 		return nil, errors.Wrapf(err, "unable to process JAMF creation request for computer extension attribute: %v (%s)", content.Name, ep)
 	}
@@ -133,8 +133,8 @@ func (j *Client) CreateComputerExtenstionAttribute(content *ComputerExtenstionAt
 	return &res, nil
 }
 
-// DeleteComputerExtenstionAttribute will delete a computer extension attribute by either ID or Name
-func (j *Client) DeleteComputerExtenstionAttribute(identifier interface{}) (*ComputerExtenstionAttribute, error) {
+// DeleteComputerExtensionAttribute will delete a computer extension attribute by either ID or Name
+func (j *Client) DeleteComputerExtensionAttribute(identifier interface{}) (*ComputerExtensionAttribute, error) {
 	ep, err := EndpointBuilder(j.Endpoint, computerExtAttrContext, identifier)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error building JAMF query request for computer extension attribute: %v", identifier)
@@ -145,7 +145,7 @@ func (j *Client) DeleteComputerExtenstionAttribute(identifier interface{}) (*Com
 		return nil, errors.Wrapf(err, "error building JAMF deletion request for computer extension attribute: %v (%s)", identifier, ep)
 	}
 
-	res := ComputerExtenstionAttribute{}
+	res := ComputerExtensionAttribute{}
 	if err := j.makeAPIrequest(req, &res); err != nil {
 		return nil, errors.Wrapf(err, "unable to process JAMF deletion request for computer extension attribute: %v (%s)", identifier, ep)
 	}

--- a/classic/computer_extenstion_attr_entity.go
+++ b/classic/computer_extenstion_attr_entity.go
@@ -24,7 +24,7 @@ type ComputerExtenstionAttribute struct {
 	XMLName          xml.Name                        `json:"-" xml:"computer_extension_attribute,omitempty"`
 	ID               int                             `json:"id" xml:"id,omitempty"`
 	Name             string                          `json:"name" xml:"name,omitempty"`
-	Enabled          bool                            `json:"enabled" xml:"enabled,omitempty"`
+	Enabled          bool                            `json:"enabled" xml:"enabled"` // we don't omit since false values are omitted if needed this can be changed to a *bool
 	Description      string                          `json:"description,omitempty" xml:"description,omitempty"`
 	DataType         string                          `json:"data_type,omitempty" xml:"data_type,omitempty"`
 	InputType        *ComputerExtensionAttrInputType `json:"input_type,omitempty" xml:"input_type,omitempty"`

--- a/classic/computer_extenstion_attr_entity.go
+++ b/classic/computer_extenstion_attr_entity.go
@@ -9,18 +9,18 @@ import (
 	"strings"
 )
 
-// CompterExtensionAttributes represents all attributes that exist in Jamf
-type CompterExtensionAttributes struct {
-	List []ComputerExtenstionAttribute `json:"computer_extension_attributes"`
+// ComputerExtensionAttributes represents all attributes that exist in Jamf
+type ComputerExtensionAttributes struct {
+	List []ComputerExtensionAttribute `json:"computer_extension_attributes"`
 }
 
 // ComputerExtensionAttributeDetails holds the details for a single extension attribute
 type ComputerExtensionAttributeDetails struct {
-	Details ComputerExtenstionAttribute `json:"computer_extension_attribute"`
+	Details ComputerExtensionAttribute `json:"computer_extension_attribute"`
 }
 
-// ComputerExtenstionAttribute represents an extension attribute in Jamf
-type ComputerExtenstionAttribute struct {
+// ComputerExtensionAttribute represents an extension attribute in Jamf
+type ComputerExtensionAttribute struct {
 	XMLName          xml.Name                        `json:"-" xml:"computer_extension_attribute,omitempty"`
 	ID               int                             `json:"id" xml:"id,omitempty"`
 	Name             string                          `json:"name" xml:"name,omitempty"`
@@ -40,7 +40,7 @@ type ComputerExtensionAttrInputType struct {
 }
 
 // ValidateComputerExtensionAttribute orchestrates computer extension content validation
-func ValidateComputerExtensionAttribute(ce *ComputerExtenstionAttribute) error {
+func ValidateComputerExtensionAttribute(ce *ComputerExtensionAttribute) error {
 	if err := ce.ValidateDataType(); err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func ValidateComputerExtensionAttribute(ce *ComputerExtenstionAttribute) error {
 }
 
 // ValidateDataType will validate that a computer extension attribute's data type is valid
-func (ce *ComputerExtenstionAttribute) ValidateDataType() error {
+func (ce *ComputerExtensionAttribute) ValidateDataType() error {
 	switch strings.ToLower(ce.DataType) {
 	case "", "string", "integer", "date":
 		return nil
@@ -73,7 +73,7 @@ func (ce *ComputerExtenstionAttribute) ValidateDataType() error {
 }
 
 // ValidateInventoryDisplay will validate that a computer extension attribute's data type is valid
-func (ce *ComputerExtenstionAttribute) ValidateInventoryDisplay() error {
+func (ce *ComputerExtensionAttribute) ValidateInventoryDisplay() error {
 	switch strings.ToLower(ce.InventoryDisplay) {
 	case "", "general", "hardware", "operating system", "user and location", "purchasing", "extension attributes":
 		return nil
@@ -83,7 +83,7 @@ func (ce *ComputerExtenstionAttribute) ValidateInventoryDisplay() error {
 }
 
 // ValidateReconDisplay will validate that a computer extension attribute's data type is valid
-func (ce *ComputerExtenstionAttribute) ValidateReconDisplay() error {
+func (ce *ComputerExtensionAttribute) ValidateReconDisplay() error {
 	switch strings.ToLower(ce.ReconDisplay) {
 	case "", "computer", "user and location", "purchasing", "extension attributes":
 		return nil

--- a/classic/computer_extenstion_attr_entity.go
+++ b/classic/computer_extenstion_attr_entity.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+package classic
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+// CompterExtensionAttributes represents all attributes that exist in Jamf
+type CompterExtensionAttributes struct {
+	List []ComputerExtenstionAttribute `json:"computer_extension_attributes"`
+}
+
+// ComputerExtensionAttributeDetails holds the details for a single extension attribute
+type ComputerExtensionAttributeDetails struct {
+	Details ComputerExtenstionAttribute `json:"computer_extension_attribute"`
+}
+
+// ComputerExtenstionAttribute represents an extension attribute in Jamf
+type ComputerExtenstionAttribute struct {
+	XMLName          xml.Name                        `json:"-" xml:"computer_extension_attribute,omitempty"`
+	ID               int                             `json:"id" xml:"id,omitempty"`
+	Name             string                          `json:"name" xml:"name,omitempty"`
+	Enabled          bool                            `json:"enabled" xml:"enabled,omitempty"`
+	Description      string                          `json:"description,omitempty" xml:"description,omitempty"`
+	DataType         string                          `json:"data_type,omitempty" xml:"data_type,omitempty"`
+	InputType        *ComputerExtensionAttrInputType `json:"input_type,omitempty" xml:"input_type,omitempty"`
+	InventoryDisplay string                          `json:"inventory_display,omitempty" xml:"inventory_display,omitempty"`
+	ReconDisplay     string                          `json:"recon_display,omitempty" xml:"recon_display,omitempty"`
+}
+
+// ComputerExtensionAttrInputType represents an input type for a computer extension attribute in Jamf
+type ComputerExtensionAttrInputType struct {
+	Type     string `json:"type,omitempty" xml:"type,omitempty"`
+	Platform string `json:"platform,omitempty" xml:"platform,omitempty"`
+	Script   string `json:"script,omitempty" xml:"script,omitempty"`
+}
+
+// ValidateComputerExtensionAttribute orchestrates computer extension content validation
+func ValidateComputerExtensionAttribute(ce *ComputerExtenstionAttribute) error {
+	if err := ce.ValidateDataType(); err != nil {
+		return err
+	}
+
+	if ce.InputType != nil {
+		if err := ce.InputType.ValidateInputType(); err != nil {
+			return err
+		}
+	}
+
+	if err := ce.ValidateReconDisplay(); err != nil {
+		return err
+	}
+
+	if err := ce.ValidateInventoryDisplay(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateDataType will validate that a computer extension attribute's data type is valid
+func (ce *ComputerExtenstionAttribute) ValidateDataType() error {
+	switch strings.ToLower(ce.DataType) {
+	case "", "string", "integer", "date":
+		return nil
+	default:
+		return fmt.Errorf("%s is not a valid computer extension attribute data type must be of type [ String, Integer, Date ]", ce.DataType)
+	}
+}
+
+// ValidateInventoryDisplay will validate that a computer extension attribute's data type is valid
+func (ce *ComputerExtenstionAttribute) ValidateInventoryDisplay() error {
+	switch strings.ToLower(ce.InventoryDisplay) {
+	case "", "general", "hardware", "operating system", "user and location", "purchasing", "extension attributes":
+		return nil
+	default:
+		return fmt.Errorf("%s is not a valid computer extension inventory display type must be of type [ General, Hardware, Operating System, User and Location, Purchasing, Extension Attributes ]", ce.InventoryDisplay)
+	}
+}
+
+// ValidateReconDisplay will validate that a computer extension attribute's data type is valid
+func (ce *ComputerExtenstionAttribute) ValidateReconDisplay() error {
+	switch strings.ToLower(ce.ReconDisplay) {
+	case "", "computer", "user and location", "purchasing", "extension attributes":
+		return nil
+	default:
+		return fmt.Errorf("%s is not a valid computer extension inventory display type must be of type [ Computer, User and Location, Purchasing, Extension Attributes ]", ce.ReconDisplay)
+	}
+}
+
+// ValidateInputType will validate that a computer extension attribute's input type is valid
+func (it *ComputerExtensionAttrInputType) ValidateInputType() error {
+	switch it.Type {
+	case "", "Text Field", "LDAP Mapping", "Pop-up Menu":
+		return nil
+	case "script":
+		if it.Script == "" {
+			return fmt.Errorf("script contents must be provided for input type %s", it.Type)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%s is not a valid computer extension attribute input type must be of type [ script, Text Field, LDAP Mapping, Pop-up Menu ]", it.Type)
+	}
+}

--- a/classic/computer_extenstion_attr_entity_test.go
+++ b/classic/computer_extenstion_attr_entity_test.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2020 Datadog, Inc.
+
+package classic_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	jamf "github.com/DataDog/jamf-api-client-go/classic"
+	"github.com/stretchr/testify/assert"
+)
+
+var COMPUTER_EXT_ATTR_API_BASE_ENDPOINT = "/JSSResource/computerextensionattributes"
+
+func computerExtResponseMocks(t *testing.T) *httptest.Server {
+	var resp string
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.RequestURI {
+		case COMPUTER_EXT_ATTR_API_BASE_ENDPOINT:
+			fmt.Fprintf(w, `{
+				"scripts": [
+					{
+							"id": 33,
+							"name": "Check Firewall"
+					},
+					{
+							"id": 99,
+							"name": "Is Logged In User Admin"
+					},
+					{
+							"id": 103,
+							"name": "Team"
+					}]
+			}`)
+		case fmt.Sprintf("%s/id/33", COMPUTER_EXT_ATTR_API_BASE_ENDPOINT), fmt.Sprintf("%s/id/-1", COMPUTER_EXT_ATTR_API_BASE_ENDPOINT), fmt.Sprintf("%s/name/Check Firewall", COMPUTER_EXT_ATTR_API_BASE_ENDPOINT):
+			switch r.Method {
+			case "PUT", "POST":
+				data, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					fmt.Fprintf(w, err.Error())
+				}
+				compExtAttrContents := &jamf.ComputerExtenstionAttribute{}
+				err = xml.Unmarshal(data, compExtAttrContents)
+				if err != nil {
+					fmt.Fprintf(w, err.Error())
+				}
+				compExtData, err := json.MarshalIndent(compExtAttrContents, "", "    ")
+				if err != nil {
+					fmt.Fprintf(w, err.Error())
+				}
+				fmt.Fprintf(w, string(compExtData))
+			default:
+				mockCompExtAttr := &jamf.ComputerExtenstionAttribute{
+					ID:          33,
+					Name:        "Check Firewall",
+					Enabled:     true,
+					Description: "Checks to ensure firewall is enabled on client",
+					DataType:    "String",
+					InputType: &jamf.ComputerExtensionAttrInputType{
+						Type: "",
+					},
+					InventoryDisplay: "Operating System",
+					ReconDisplay:     "Extension Attributes",
+				}
+
+				compExtData, err := json.MarshalIndent(mockCompExtAttr, "", "    ")
+				if err != nil {
+					fmt.Fprintf(w, err.Error())
+				}
+				fmt.Fprintf(w, string(compExtData))
+			}
+		default:
+			http.Error(w, fmt.Sprintf("bad Jamf API %s call to %s", r.Method, r.URL), http.StatusInternalServerError)
+			return
+		}
+		_, err := w.Write([]byte(resp))
+		assert.Nil(t, err)
+	}))
+}

--- a/classic/computer_extenstion_attr_entity_test.go
+++ b/classic/computer_extenstion_attr_entity_test.go
@@ -45,7 +45,7 @@ func computerExtResponseMocks(t *testing.T) *httptest.Server {
 				if err != nil {
 					fmt.Fprintf(w, err.Error())
 				}
-				compExtAttrContents := &jamf.ComputerExtenstionAttribute{}
+				compExtAttrContents := &jamf.ComputerExtensionAttribute{}
 				err = xml.Unmarshal(data, compExtAttrContents)
 				if err != nil {
 					fmt.Fprintf(w, err.Error())
@@ -56,7 +56,7 @@ func computerExtResponseMocks(t *testing.T) *httptest.Server {
 				}
 				fmt.Fprintf(w, string(compExtData))
 			default:
-				mockCompExtAttr := &jamf.ComputerExtenstionAttribute{
+				mockCompExtAttr := &jamf.ComputerExtensionAttribute{
 					ID:          33,
 					Name:        "Check Firewall",
 					Enabled:     true,

--- a/docs/api_coverage.md
+++ b/docs/api_coverage.md
@@ -4,6 +4,12 @@
     - [x] Get specific computer by [ID](https://www.jamf.com/developers/apis/classic/reference/#/computers/findComputersById) or [Name](https://www.jamf.com/developers/apis/classic/reference/#/computers/findComputersByName)
     - [x] Update computer by [ID](https://www.jamf.com/developers/apis/classic/reference/#/computers/updateComputerById) or [Name](https://www.jamf.com/developers/apis/classic/reference/#/computers/updateComputerByName)
 
+  - `/computerextensionattributes`
+    - [x] [Get all computer extension attributes](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/Computerextensionattributes)
+    - [x] Get specific computer extension attribute by [ID](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/findComputerextensionattributeById) or [Name](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/findComputerextensionattributeByName)
+    - [x] Update computer extension attribute by [ID](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/updateComputerextensionattributeById) or [Name](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/updateComputerextensionattributeByName)
+    - [x] Delete computer extensio nattribute by [ID](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/deleteComputerextensionattributeById) or [Name](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/deleteComputerextensionattributeByName)
+
   - `/scripts`
     - [x] [Get all scripts](https://www.jamf.com/developers/apis/classic/reference/#/scripts/findScripts)
     - [x] Get specific script by [ID](https://www.jamf.com/developers/apis/classic/reference/#/scripts/findScriptsById) or [Name](https://www.jamf.com/developers/apis/classic/reference/#/scripts/findScriptsByName) **Note:** only JSON response available for GET requests (XML Unmarshalling not currently configured)

--- a/docs/api_coverage.md
+++ b/docs/api_coverage.md
@@ -7,6 +7,7 @@
   - `/computerextensionattributes`
     - [x] [Get all computer extension attributes](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/Computerextensionattributes)
     - [x] Get specific computer extension attribute by [ID](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/findComputerextensionattributeById) or [Name](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/findComputerextensionattributeByName)
+    - [x] Create new computer extension attribute by [ID](https://www.jamf.com/developers/apis/classic/reference/#/policies/createComputerextensionattributeById) 
     - [x] Update computer extension attribute by [ID](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/updateComputerextensionattributeById) or [Name](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/updateComputerextensionattributeByName)
     - [x] Delete computer extensio nattribute by [ID](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/deleteComputerextensionattributeById) or [Name](https://www.jamf.com/developers/apis/classic/reference/#/computerextensionattributes/deleteComputerextensionattributeByName)
 

--- a/examples/computer-ext-attr/main.go
+++ b/examples/computer-ext-attr/main.go
@@ -97,7 +97,7 @@ func main() {
 		    "computer_extension_attribute": {
 		        "id": 21,
 		        "name": "Test Extension Attribute for API",
-		        "enabled": true,
+		        "enabled": false,
 		        "description": "This is testing the Jamf Go API Client",
 		        "data_type": "String",
 		        "input_type": {

--- a/examples/computer-ext-attr/main.go
+++ b/examples/computer-ext-attr/main.go
@@ -62,7 +62,7 @@ func main() {
 	*/
 
 	// update existing computer extension attribute
-	updatedDetails := &jamf.ComputerExtenstionAttribute{
+	updatedDetails := &jamf.ComputerExtensionAttribute{
 		Description: "This is an example of a description update",
 	}
 	updatedCompExtAttr, err := j.UpdateComputerExtensionAttribue(12, updatedDetails)
@@ -75,7 +75,7 @@ func main() {
 	*/
 
 	// create new computer extnesion attribute
-	newExtAttr := &jamf.ComputerExtenstionAttribute{
+	newExtAttr := &jamf.ComputerExtensionAttribute{
 		Name:        "Test Extension Attribute for API",
 		Enabled:     false,
 		Description: "This is testing the Jamf Go API Client",
@@ -89,7 +89,7 @@ func main() {
 		ReconDisplay:     "Extension Attributes",
 	}
 
-	created, err := j.CreateComputerExtenstionAttribute(newExtAttr)
+	created, err := j.CreateComputerExtensionAttribute(newExtAttr)
 	checkAndHandleErr(err)
 	fmt.Printf("Created %s - ID: %d\n\n", created.Name, created.ID)
 	/*
@@ -114,7 +114,7 @@ func main() {
 	// Note if you run this example the server can't find the new ID right away
 	// so we sleep for 30 seconds
 	time.Sleep(30 * time.Second)
-	deleted, err := j.DeleteComputerExtenstionAttribute(created.ID) // Can delete using ID or Name
+	deleted, err := j.DeleteComputerExtensionAttribute(created.ID) // Can delete using ID or Name
 	checkAndHandleErr(err)
 	fmt.Printf("Deleted ID: %d\n", deleted.ID)
 

--- a/examples/computer-ext-attr/main.go
+++ b/examples/computer-ext-attr/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	jamf "github.com/DataDog/jamf-api-client-go/classic"
+)
+
+func checkAndHandleErr(err error) {
+	if err != nil {
+		fmt.Println(err.Error())
+		panic(1)
+	}
+}
+
+func main() {
+	username := os.Getenv("JAMF_USERNAME")
+	password := os.Getenv("JAMF_PASSWORD")
+	domain := os.Getenv("JAMF_DOMAIN")
+
+	j, err := jamf.NewClient(domain, username, password, nil)
+	checkAndHandleErr(err)
+
+	// list computer extenstion attribues
+	extAttrs, err := j.ComputerExtensionAttributes()
+	checkAndHandleErr(err)
+
+	for _, attr := range extAttrs.List[:len(extAttrs.List)/3] {
+		fmt.Printf("Extension Attribute: %s\n", attr.Name)
+	}
+	fmt.Printf("\n")
+
+	// get details about a specific extension attribute
+	extrAttrDetails, err := j.ComputerExtensionAttributeDetails(12)
+	checkAndHandleErr(err)
+
+	detailsBytes, err := json.Marshal(extrAttrDetails.Details)
+	checkAndHandleErr(err)
+
+	prettyExtAttrDetails := jamf.JSONPrettyPrint(detailsBytes)
+	fmt.Printf("%s\n\n", prettyExtAttrDetails)
+	/*
+			{
+		    "computer_extension_attribute": {
+		        "id": 21,
+		        "name": "Test Extension Attribute for API",
+		        "enabled": true,
+		        "description": "This is testing the Jamf Go API Client",
+		        "data_type": "String",
+		        "input_type": {
+		            "type": "script",
+		            "platform": "Mac",
+		            "script": "#!/bin/bash\necho 'hello world'"
+		        },
+		        "inventory_display": "Extension Attributes",
+		        "recon_display": "Extension Attributes"
+		    }
+		}
+	*/
+
+	// update existing computer extension attribute
+	updatedDetails := &jamf.ComputerExtenstionAttribute{
+		Description: "This is an example of a description update",
+	}
+	updatedCompExtAttr, err := j.UpdateComputerExtensionAttribue(12, updatedDetails)
+	checkAndHandleErr(err)
+	fmt.Printf("Updated description for ID: %d\n\n", updatedCompExtAttr.ID)
+	/*
+		<computer_extension_attribute>
+		    <id>{{ ID From Above}}</id>
+		</computer_extension_attribute>
+	*/
+
+	// create new computer extnesion attribute
+	newExtAttr := &jamf.ComputerExtenstionAttribute{
+		Name:        "Test Extension Attribute for API",
+		Enabled:     false,
+		Description: "This is testing the Jamf Go API Client",
+		DataType:    "String",
+		InputType: &jamf.ComputerExtensionAttrInputType{
+			Type:     "script",
+			Platform: "Mac",
+			Script:   "#!/bin/bash\r\necho 'hello world'",
+		},
+		InventoryDisplay: "Extension Attributes",
+		ReconDisplay:     "Extension Attributes",
+	}
+
+	created, err := j.CreateComputerExtenstionAttribute(newExtAttr)
+	checkAndHandleErr(err)
+	fmt.Printf("Created %s - ID: %d\n\n", created.Name, created.ID)
+	/*
+			{
+		    "computer_extension_attribute": {
+		        "id": 21,
+		        "name": "Test Extension Attribute for API",
+		        "enabled": true,
+		        "description": "This is testing the Jamf Go API Client",
+		        "data_type": "String",
+		        "input_type": {
+		            "type": "script",
+		            "platform": "Mac",
+		            "script": "#!/bin/bash\necho 'hello world'"
+		        },
+		        "inventory_display": "Extension Attributes",
+		        "recon_display": "Extension Attributes"
+		    }
+		}
+	*/
+
+	// Note if you run this example the server can't find the new ID right away
+	// so we sleep for 30 seconds
+	time.Sleep(30 * time.Second)
+	deleted, err := j.DeleteComputerExtenstionAttribute(created.ID) // Can delete using ID or Name
+	checkAndHandleErr(err)
+	fmt.Printf("Deleted ID: %d\n", deleted.ID)
+
+	/*
+		<computer_extension_attribute>
+		    <id>{{ ID From Above}}</id>
+		</computer_extension_attribute>
+	*/
+}


### PR DESCRIPTION
## What does this PR do?

- Adds `/computerextensionattribute` endpoint support
- **Unit tests to be added in a follow-up PR to keep diff smaller**

## PR Checklist 

- [x] The title & description contain a short meaningful summary of work completed
- [ ] Tests have been updated/created and are passing locally
- [x] Related documentation and [CHANGELOG](https://github.com/DataDog/jamf-api-client-go/blob/main/CHANGELOG.md) have been updated
- [x] I reviewed the [contributing](https://github.com/DataDog/jamf-api-client-go/blob/main/CONTRIBUTING.md) documentation
