### PR TITLE
[MISC] Updating release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .coverage.html
 coverage.html
 cp.out
+bin/
 
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,9 @@ Github issues are welcome, feel free to submit error reports and feature request
 - Fork a repository
 - Add new functionality or apply a fix
 - Check that tests are passing
-- Create PR against `main` and await review/approval. Please review the outlined process below to ensure your PR is good to go.
+- Create PR against the latest `release/*` branch (or create one if applicable) and await review/approval.
+
+**Please review the outlined process below to ensure your PR is good to go.**
 
 ## Pull Request Process
 
@@ -36,7 +38,9 @@ Github issues are welcome, feel free to submit error reports and feature request
   
 2. Unless what you are doing is absolutely trivial, add unit tests. Good unit tests come in bundles,
    and usually test for both the expected and how one handles the unexpected case. To ensure your tests 
-   pass please run `go test -v ./...` or `make test` from the root of this repo.
+   pass please run `go test -v ./...` or `make pr-prep` from the root of this repo. We believe that smaller scoped PR's
+   make the review process easier on everyone. Therefore, if you would prefer to submit your tests in a follow up PR please
+   notate that in the description of the PR so the reviewer knows and be a good citizen.
 
 3. If you are making changes that add new components, new data structures, or reorganize an existing
    flow, it is helpful to discuss your architecture first. That discussion is better had over an

--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,7 @@ test-integration:
 	@go test -v -coverprofile=cp.out  -count=1 -timeout 600s ${DIRS}
 	go tool cover -html=cp.out -o .coverage.html
 
-pr-prep: clean fmt lint test-race test-integration
+build:
+	@go build -ldflags="-s -w" -o bin/jamf-api-client-go ./classic
+
+pr-prep: clean deps fmt lint test-race test-integration

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ if err != nil {
   os.Exit(1)
 }
 ```
+
+More examples available [here](https://github.com/DataDog/jamf-api-client-go/tree/main/examples)
 ### Tests
 
 Unit tests should exist for all endpoints and pass successfully prior to being checked into the `main` branch
@@ -65,18 +67,3 @@ Unit tests should exist for all endpoints and pass successfully prior to being c
  `go test -v ./...` or `make test`
 
  Alternatively, `make pr-prep` can be run to execute all tests, formatting, and linting
-
-### Releasing
-
-When a release is ready to be pushed:
-- Ensure all intended changes have been merged to `main`
-- Create a release on the releases page.
-- Specify the version you want to release, following [Semantic Versioning](https://semver.org/spec) principles.
-  
-  > If the tag isn’t meant for production use, add a pre-release version after the version name. Some good pre-release versions might be v0.2-alpha or v5.9-beta.3
-
-- Add release title containing the relase version if desired `ex v1.0.0-beta1 Initial Beta Release`
-- Add sufficient changelog contents into the description of the release. (`git log` may be helpful)
-- Create/Publish the release, which will automatically create a tag on the HEAD commit. (no binaries should be uploaded)
-
-Once a versioned package has been released, the contents of that version **MUST NOT** be modified. Any modifications must be released as a new version.

--- a/docs/new_releases.md
+++ b/docs/new_releases.md
@@ -1,0 +1,19 @@
+### Releasing
+
+To prep a new release create a release branch in the format `release/{release number}` and push it to the remote. 
+
+Once the branch is available create a feature branch off of the relase branch, this will allow us to group new functionality together for each release and `main` will always represent the latest official release.
+
+When a release is ready to be pushed:
+- Ensure all intended changes have been merged into the release branch and all tests are passing
+- Merge the release branch into `main`
+- Create a release on the releases page.
+- Specify the version you want to release, following [Semantic Versioning](https://semver.org/spec) principles.
+  
+  > If the tag isn’t meant for production use, add a pre-release version after the version name. Some good pre-release versions might be v0.2-alpha or v5.9-beta.3
+
+- Add release title containing the relase version if desired `ex v1.0.0-beta1 Initial Beta Release`
+- Add sufficient changelog contents into the description of the release. (`git log` may be helpful)
+- Create/Publish the release, which will automatically create a tag on the HEAD commit. (no binaries should be uploaded)
+
+Once a versioned package has been released, the contents of that version **MUST NOT** be modified. Any modifications must be released as a new version.


### PR DESCRIPTION
## What does this PR do?

- Minor adjustment to release workflow
- Moved the release docs into the `docs/` directory
- Updates contributing guide to reflect updates
- Adds local build command to Makefile and update .gitignore to exclude `bin/`

## PR Checklist 

- [x] The title & description contain a short meaningful summary of work completed
- [x] Tests have been updated/created and are passing locally
- [x] Related documentation and [CHANGELOG](https://github.com/DataDog/jamf-api-client-go/blob/main/CHANGELOG.md) have been updated
- [x] I reviewed the [contributing](https://github.com/DataDog/jamf-api-client-go/blob/main/CONTRIBUTING.md) documentation
