### PR TITLE
[REFACTOR] making list related methods consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0.beta.3
+- Refactors list methods to return list of objects by default i.e `j.Computers() => []BasicComputerInfo`.
+- Refactors list related structs to use `List` key
 ## 1.0.0.beta.2
 - Adds support for `/computerextensionattributes` endpoint
 - Fixes minor typo in `client.go` causing tests to fail

--- a/classic/computer.go
+++ b/classic/computer.go
@@ -12,18 +12,18 @@ import (
 )
 
 // Computers returns all enrolled computer devices
-func (j *Client) Computers() (*ComputerList, error) {
+func (j *Client) Computers() ([]BasicComputerInfo, error) {
 	ep := fmt.Sprintf("%s/%s", j.Endpoint, computersContext)
 	req, err := http.NewRequestWithContext(context.Background(), "GET", ep, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error building JAMF computer query request")
 	}
 
-	res := &ComputerList{}
+	res := &Computers{}
 	if err := j.makeAPIrequest(req, &res); err != nil {
 		return nil, errors.Wrapf(err, "unable to query enrolled computers from %s", ep)
 	}
-	return res, nil
+	return res.List, nil
 }
 
 // ComputerDetails returns the details for a specific computer given its ID

--- a/classic/computer_entity.go
+++ b/classic/computer_entity.go
@@ -5,9 +5,9 @@ package classic
 
 import "encoding/xml"
 
-// ComputerList represents a list of computers enrolled in Jamf
-type ComputerList struct {
-	Computers []BasicComputerInfo `json:"computers"`
+// Computers represents a list of computers enrolled in Jamf
+type Computers struct {
+	List []BasicComputerInfo `json:"computers"`
 }
 
 // ComputerGroup represents a group a device is a member of in Jamf

--- a/classic/computer_extension_attr.go
+++ b/classic/computer_extension_attr.go
@@ -29,7 +29,7 @@ func (j *Client) ComputerExtensionAttrExists(identifier interface{}) bool {
 }
 
 // ComputerExtensionAttributes returns all computer extension attributes
-func (j *Client) ComputerExtensionAttributes() (*ComputerExtensionAttributes, error) {
+func (j *Client) ComputerExtensionAttributes() ([]ComputerExtensionAttribute, error) {
 	ep := fmt.Sprintf("%s/%s", j.Endpoint, computerExtAttrContext)
 	req, err := http.NewRequestWithContext(context.Background(), "GET", ep, nil)
 	if err != nil {
@@ -40,7 +40,7 @@ func (j *Client) ComputerExtensionAttributes() (*ComputerExtensionAttributes, er
 	if err := j.makeAPIrequest(req, &res); err != nil {
 		return nil, errors.Wrapf(err, "unable to query computer extension attribute from %s", ep)
 	}
-	return res, nil
+	return res.List, nil
 }
 
 // ComputerExtensionAttributeDetails returns the details for a specific computer extension attribute given its ID or Name

--- a/classic/computer_extension_attr_test.go
+++ b/classic/computer_extension_attr_test.go
@@ -106,10 +106,10 @@ func TestQueryAllComputerExtAttrs(t *testing.T) {
 	assert.Nil(t, err)
 	compExtAttrs, err := j.ComputerExtensionAttributes()
 	assert.Nil(t, err)
-	assert.NotNil(t, compExtAttrs.List)
-	assert.Equal(t, 3, len(compExtAttrs.List))
-	assert.Equal(t, 99, compExtAttrs.List[1].ID)
-	assert.Equal(t, "Is Logged In User Admin", compExtAttrs.List[1].Name)
+	assert.NotNil(t, compExtAttrs)
+	assert.Equal(t, 3, len(compExtAttrs))
+	assert.Equal(t, 99, compExtAttrs[1].ID)
+	assert.Equal(t, "Is Logged In User Admin", compExtAttrs[1].Name)
 }
 
 func TestQuerySpecificComputerExtAttrByName(t *testing.T) {

--- a/classic/computer_test.go
+++ b/classic/computer_test.go
@@ -168,10 +168,10 @@ func TestQueryComputer(t *testing.T) {
 	assert.Nil(t, err)
 	computers, err := j.Computers()
 	assert.Nil(t, err)
-	assert.NotNil(t, computers.Computers)
-	assert.Equal(t, 6, len(computers.Computers))
-	assert.Equal(t, 3, computers.Computers[0].ID)
-	assert.Equal(t, "Test MacBook #3", computers.Computers[0].Name)
+	assert.NotNil(t, computers)
+	assert.Equal(t, 6, len(computers))
+	assert.Equal(t, 3, computers[0].ID)
+	assert.Equal(t, "Test MacBook #3", computers[0].Name)
 }
 
 func TestQuerySpecificComputer(t *testing.T) {

--- a/classic/policy.go
+++ b/classic/policy.go
@@ -14,17 +14,17 @@ import (
 )
 
 // Policies returns a list of policies available in the jamf client
-func (j *Client) Policies() (*PolicyList, error) {
+func (j *Client) Policies() ([]BasicPolicyInformation, error) {
 	ep := fmt.Sprintf("%s/%s", j.Endpoint, policiesContext)
 	req, err := http.NewRequestWithContext(context.Background(), "GET", ep, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error building Jamf policies query request")
 	}
-	res := PolicyList{}
+	res := Policies{}
 	if err := j.makeAPIrequest(req, &res); err != nil {
 		return nil, errors.Wrapf(err, "unable to query available policies from %s", ep)
 	}
-	return &res, nil
+	return res.List, nil
 }
 
 // PolicyDetails returns the details for a specific policy given its ID or Name

--- a/classic/policy_entity.go
+++ b/classic/policy_entity.go
@@ -5,9 +5,9 @@ package classic
 
 import "encoding/xml"
 
-// PolicyList holds all policies in the configured Jamf environment
-type PolicyList struct {
-	Policies []BasicPolicyInformation `json:"policies"`
+// Policies holds all policies in the configured Jamf environment
+type Policies struct {
+	List []BasicPolicyInformation `json:"policies"`
 }
 
 // BasicPolicyInformation holds the basic information for all policies in Jamf

--- a/classic/policy_test.go
+++ b/classic/policy_test.go
@@ -98,10 +98,10 @@ func TestGetAllPolicies(t *testing.T) {
 	assert.Nil(t, err)
 	res, err := j.Policies()
 	assert.Nil(t, err)
-	assert.NotNil(t, res.Policies)
-	assert.Len(t, res.Policies, 5)
-	assert.Equal(t, 72, res.Policies[2].ID)
-	assert.Equal(t, "Test Policy", res.Policies[2].Name)
+	assert.NotNil(t, res)
+	assert.Len(t, res, 5)
+	assert.Equal(t, 72, res[2].ID)
+	assert.Equal(t, "Test Policy", res[2].Name)
 }
 
 func TestGetSpecificPolicyByID(t *testing.T) {

--- a/classic/scripts.go
+++ b/classic/scripts.go
@@ -14,17 +14,17 @@ import (
 )
 
 // Scripts returns a list of scripts available in the jamf client
-func (j *Client) Scripts() (*ScriptsList, error) {
+func (j *Client) Scripts() ([]BasicScriptInfo, error) {
 	ep := fmt.Sprintf("%s/%s", j.Endpoint, scriptsContext)
 	req, err := http.NewRequestWithContext(context.Background(), "GET", ep, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error building JAMF scripts query request")
 	}
-	res := ScriptsList{}
+	res := Scripts{}
 	if err := j.makeAPIrequest(req, &res); err != nil {
 		return nil, errors.Wrapf(err, "unable to query available scripts from %s", ep)
 	}
-	return &res, nil
+	return res.List, nil
 }
 
 // ScriptDetails returns the details for a specific script given its ID or Name

--- a/classic/scripts_entity.go
+++ b/classic/scripts_entity.go
@@ -5,9 +5,9 @@ package classic
 
 import "encoding/xml"
 
-// ScriptsList holds a list of all the scripts available in Jamf
-type ScriptsList struct {
-	Scripts []BasicScriptInfo `json:"scripts"`
+// Scripts holds a list of all the scripts available in Jamf
+type Scripts struct {
+	List []BasicScriptInfo `json:"scripts"`
 }
 
 // BasicScriptInfo holds the most basic information about the scripts available in Jamf

--- a/classic/scripts_test.go
+++ b/classic/scripts_test.go
@@ -112,10 +112,10 @@ func TestGetAllScripts(t *testing.T) {
 	assert.Nil(t, err)
 	scripts, err := j.Scripts()
 	assert.Nil(t, err)
-	assert.NotNil(t, scripts.Scripts)
-	assert.Len(t, scripts.Scripts, 6)
-	assert.Equal(t, 33, scripts.Scripts[2].ID)
-	assert.Equal(t, "Zoom Script 2", scripts.Scripts[2].Name)
+	assert.NotNil(t, scripts)
+	assert.Len(t, scripts, 6)
+	assert.Equal(t, 33, scripts[2].ID)
+	assert.Equal(t, "Zoom Script 2", scripts[2].Name)
 }
 
 func TestGetSpecificScriptByID(t *testing.T) {

--- a/examples/comp_extension_attrs.go
+++ b/examples/comp_extension_attrs.go
@@ -28,7 +28,7 @@ func main() {
 	extAttrs, err := j.ComputerExtensionAttributes()
 	checkAndHandleErr(err)
 
-	for _, attr := range extAttrs.List[:len(extAttrs.List)/3] {
+	for _, attr := range extAttrs[:len(extAttrs)/3] {
 		fmt.Printf("Extension Attribute: %s\n", attr.Name)
 	}
 	fmt.Printf("\n")


### PR DESCRIPTION
## What does this PR do?

- List methods were not consistent across the client, updated them to return the list of items rather than requiring `<entity>.List`
- Moving examples to flat file structure

## PR Checklist 

- [x] The title & description contain a short meaningful summary of work completed
- [x] Tests have been updated/created and are passing locally
- [x] Related documentation and [CHANGELOG](https://github.com/DataDog/jamf-api-client-go/blob/main/CHANGELOG.md) have been updated
- [x] I reviewed the [contributing](https://github.com/DataDog/jamf-api-client-go/blob/main/CONTRIBUTING.md) documentation
