### PR TITLE
[FEATURE] Add IP address fields to Computer GeneralInformation

### DIFF
--- a/classic/computer_entity.go
+++ b/classic/computer_entity.go
@@ -42,15 +42,17 @@ type ComputerDetails struct {
 
 // GeneralInformation holds basic information associated with Jamf device
 type GeneralInformation struct {
-	ID           int    `json:"id,omitempty" xml:"id,omitempty"`
-	Name         string `json:"name" xml:"name,omitempty"`
-	MACAddress   string `json:"mac_address" xml:"mac_address,omitempty"`
-	SerialNumber string `json:"serial_number" xml:"serial_number,omitempty"`
-	UDID         string `json:"udid" xml:"udid,omitempty"`
-	JamfVersion  string `json:"jamf_version" xml:"jamf_version,omitempty"`
-	Platform     string `json:"platform" xml:"platform,omitempty"`
-	MDMCapable   bool   `json:"mdm_capable" xml:"mdm_capable,omitempty"`
-	ReportDate   string `json:"report_date" xml:"report_date,omitempty"`
+	ID             int    `json:"id,omitempty" xml:"id,omitempty"`
+	Name           string `json:"name" xml:"name,omitempty"`
+	MACAddress     string `json:"mac_address" xml:"mac_address,omitempty"`
+	SerialNumber   string `json:"serial_number" xml:"serial_number,omitempty"`
+	UDID           string `json:"udid" xml:"udid,omitempty"`
+	JamfVersion    string `json:"jamf_version" xml:"jamf_version,omitempty"`
+	Platform       string `json:"platform" xml:"platform,omitempty"`
+	MDMCapable     bool   `json:"mdm_capable" xml:"mdm_capable,omitempty"`
+	ReportDate     string `json:"report_date" xml:"report_date,omitempty"`
+	IPAddress      string `json:"ip_address" xml:"ip_address,omitempty"`
+	LastReportedIP string `json:"last_reported_ip" xml:"last_reported_ip,omitempty"`
 }
 
 // LocationInformation holds the information in the User & Locations section

--- a/classic/computer_entity.go
+++ b/classic/computer_entity.go
@@ -42,17 +42,18 @@ type ComputerDetails struct {
 
 // GeneralInformation holds basic information associated with Jamf device
 type GeneralInformation struct {
-	ID             int    `json:"id,omitempty" xml:"id,omitempty"`
-	Name           string `json:"name" xml:"name,omitempty"`
-	MACAddress     string `json:"mac_address" xml:"mac_address,omitempty"`
-	SerialNumber   string `json:"serial_number" xml:"serial_number,omitempty"`
-	UDID           string `json:"udid" xml:"udid,omitempty"`
-	JamfVersion    string `json:"jamf_version" xml:"jamf_version,omitempty"`
-	Platform       string `json:"platform" xml:"platform,omitempty"`
-	MDMCapable     bool   `json:"mdm_capable" xml:"mdm_capable,omitempty"`
-	ReportDate     string `json:"report_date" xml:"report_date,omitempty"`
-	IPAddress      string `json:"ip_address" xml:"ip_address,omitempty"`
-	LastReportedIP string `json:"last_reported_ip" xml:"last_reported_ip,omitempty"`
+	ID                  int    `json:"id,omitempty" xml:"id,omitempty"`
+	Name                string `json:"name" xml:"name,omitempty"`
+	MACAddress          string `json:"mac_address" xml:"mac_address,omitempty"`
+	SerialNumber        string `json:"serial_number" xml:"serial_number,omitempty"`
+	UDID                string `json:"udid" xml:"udid,omitempty"`
+	JamfVersion         string `json:"jamf_version" xml:"jamf_version,omitempty"`
+	Platform            string `json:"platform" xml:"platform,omitempty"`
+	MDMCapable          bool   `json:"mdm_capable" xml:"mdm_capable,omitempty"`
+	ReportDate          string `json:"report_date" xml:"report_date,omitempty"`
+	IPAddress           string `json:"ip_address" xml:"ip_address,omitempty"`
+	LastReportedIP      string `json:"last_reported_ip" xml:"last_reported_ip,omitempty"`
+	LastEnrolledDateUTC string `json:"last_enrolled_date_utc" xml:"last_enrolled_date_utc,omitempty"`
 }
 
 // LocationInformation holds the information in the User & Locations section

--- a/classic/computer_test.go
+++ b/classic/computer_test.go
@@ -64,7 +64,8 @@ func computerResponseMocks(t *testing.T) *httptest.Server {
 						"mdm_capable": false,
 						"report_date": "2020-09-11 23:06:00",
 						"ip_address": "192.0.2.100",
-						"last_reported_ip": "192.0.2.101"
+						"last_reported_ip": "192.0.2.101",
+						"last_enrolled_date_utc": "2022-06-01T21:58:48.585+0000"
 					},
 					"location": {
 						"username": "test.user",
@@ -227,6 +228,7 @@ func TestQuerySpecificComputer(t *testing.T) {
 	assert.Equal(t, false, computer.Info.General.MDMCapable)
 	assert.Equal(t, "192.0.2.100", computer.Info.General.IPAddress)
 	assert.Equal(t, "192.0.2.101", computer.Info.General.LastReportedIP)
+	assert.Equal(t, "2022-06-01T21:58:48.585+0000", computer.Info.General.LastEnrolledDateUTC)
 
 	// User & Location Info
 	assert.Equal(t, "Test User", computer.Info.UserLocation.RealName)

--- a/classic/computer_test.go
+++ b/classic/computer_test.go
@@ -62,7 +62,9 @@ func computerResponseMocks(t *testing.T) *httptest.Server {
 						"jamf_version": "20.18.0-t0000000000",
 						"platform": "Mac",
 						"mdm_capable": false,
-						"report_date": "2020-09-11 23:06:00"
+						"report_date": "2020-09-11 23:06:00",
+						"ip_address": "192.0.2.100",
+						"last_reported_ip": "192.0.2.101"
 					},
 					"location": {
 						"username": "test.user",
@@ -223,6 +225,8 @@ func TestQuerySpecificComputer(t *testing.T) {
 	assert.Equal(t, 82, computer.Info.General.ID)
 	assert.Equal(t, "Go Client Test Machine", computer.Info.General.Name)
 	assert.Equal(t, false, computer.Info.General.MDMCapable)
+	assert.Equal(t, "192.0.2.100", computer.Info.General.IPAddress)
+	assert.Equal(t, "192.0.2.101", computer.Info.General.LastReportedIP)
 
 	// User & Location Info
 	assert.Equal(t, "Test User", computer.Info.UserLocation.RealName)


### PR DESCRIPTION
## What does this PR do?

This change adds the `ip_address` and `last_reported_ip` fields to the `GeneralInformation` struct used in responses for methods that return a populated `Computer` struct.

These fields are documented in Jamf at https://docs.jamf.com/10.39.0/jamf-pro/documentation/Computer_Inventory_and_Criteria_Reference.html#reference-129 with specifics about the two fields here https://docs.jamf.com/technical-articles/Collecting_the_IP_Address_and_Reported_IP_Address_in_Jamf_Pro.html

## PR Checklist 

- [x] The title & description contain a short meaningful summary of work completed
- [x] Tests have been updated/created and are passing locally
- [ ] Related documentation and [CHANGELOG](https://github.com/DataDog/jamf-api-client-go/blob/main/CHANGELOG.md) have been updated 
☝️ **(I'm not sure which release would be next since I do not have any visibility into changes that may be staged)** ☝️
- [x] I reviewed the [contributing](https://github.com/DataDog/jamf-api-client-go/blob/main/CONTRIBUTING.md) documentation

## Related PRs or Issues

None
