### PR TITLE
[REFACTOR] add get/update computer methods with search opts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 coverage.html
 cp.out
 bin/
+.vscode/
 
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/classic/computer_entity.go
+++ b/classic/computer_entity.go
@@ -24,52 +24,54 @@ type BasicComputerInfo struct {
 
 // Computer represents an individual computer enrolled in Jamf with all its associated information
 type Computer struct {
-	Info struct {
-		General             GeneralInformation       `json:"general"`
-		UserLocation        LocationInformation      `json:"location"`
-		Hardware            HardwareInformation      `json:"hardware"`
-		Certificates        []CertificateInformation `json:"certificates"`
-		Software            SoftwareInformation      `json:"software"`
-		ExtensionAttributes []ExtensionAttributes    `json:"extension_attributes"`
-		Groups              GroupInformation         `json:"groups_accounts"`
-		ConfigProfiles      []ConfigProfile          `json:"configuration_profiles"`
-	} `json:"computer"`
+	Info ComputerDetails `json:"computer" xml:"computer,omitempty"`
+}
+
+type ComputerDetails struct {
+	XMLName             xml.Name                 `json:"-" xml:"computer,omitempty"`
+	General             GeneralInformation       `json:"general" xml:"general,omitempty"`
+	UserLocation        LocationInformation      `json:"location" xml:"location,omitempty"`
+	Hardware            HardwareInformation      `json:"hardware" xml:"-"`
+	Certificates        []CertificateInformation `json:"certificates" xml:"-"`
+	Software            SoftwareInformation      `json:"software" xml:"-"`
+	ExtensionAttributes []ExtensionAttributes    `json:"extension_attributes" xml:"extension_attributes,omitempty"`
+	Groups              GroupInformation         `json:"groups_accounts" xml:"-"`
+	ConfigProfiles      []ConfigProfile          `json:"configuration_profiles" xml:"configuration_profiles,omitempty"`
 }
 
 // GeneralInformation holds basic information associated with Jamf device
 type GeneralInformation struct {
-	XMLName      xml.Name `json:"-" xml:"computer,omitempty"`
-	ID           int      `json:"id,omitempty" xml:"id,omitempty"`
-	Name         string   `json:"name" xml:"name,omitempty"`
-	MACAddress   string   `json:"mac_address" xml:"mac_address,omitempty"`
-	SerialNumber string   `json:"serial_number" xml:"serial_number,omitempty"`
-	UDID         string   `json:"udid" xml:"udid,omitempty"`
-	JamfVersion  string   `json:"jamf_version" xml:"jamf_version,omitempty"`
-	Platform     string   `json:"platform" xml:"platform,omitempty"`
-	MDMCapable   bool     `json:"mdm_capable" xml:"mdm_capable,omitempty"`
-	ReportDate   string   `json:"report_date" xml:"report_date,omitempty"`
+	ID           int    `json:"id,omitempty" xml:"id,omitempty"`
+	Name         string `json:"name" xml:"name,omitempty"`
+	MACAddress   string `json:"mac_address" xml:"mac_address,omitempty"`
+	SerialNumber string `json:"serial_number" xml:"serial_number,omitempty"`
+	UDID         string `json:"udid" xml:"udid,omitempty"`
+	JamfVersion  string `json:"jamf_version" xml:"jamf_version,omitempty"`
+	Platform     string `json:"platform" xml:"platform,omitempty"`
+	MDMCapable   bool   `json:"mdm_capable" xml:"mdm_capable,omitempty"`
+	ReportDate   string `json:"report_date" xml:"report_date,omitempty"`
 }
 
 // LocationInformation holds the information in the User & Locations section
 type LocationInformation struct {
-	Username     string `json:"username"`
-	RealName     string `json:"realname"`
-	EmailAddress string `json:"email_address"`
-	Position     string `json:"position"`
-	Department   string `json:"department"`
-	Building     string `json:"building"`
+	Username     string `json:"username" xml:"username,omitempty"`
+	RealName     string `json:"realname" xml:"realname,omitempty"`
+	EmailAddress string `json:"email_address" xml:"email_address,omitempty"`
+	Position     string `json:"position" xml:"position,omitempty"`
+	Department   string `json:"department" xml:"department,omitempty"`
+	Building     string `json:"building" xml:"building,omitempty"`
 }
 
 // HardwareInformation holds the hardware specific device information
 type HardwareInformation struct {
-	Make             string   `json:"make"`
-	OSName           string   `json:"os_name"`
-	OSVersion        string   `json:"os_version"`
-	OSBuild          string   `json:"os_build"`
-	SIPStatus        string   `json:"sip_status"`
-	GatekeeperStatus string   `json:"gatekeeper_status"`
-	XProtectVersion  string   `json:"xprotect_version"`
-	FilevaultUsers   []string `json:"filevault2_users"`
+	Make             string   `json:"make" xml:"make,omitempty"`
+	OSName           string   `json:"os_name" xml:"os_name,omitempty"`
+	OSVersion        string   `json:"os_version" xml:"os_version,omitempty"`
+	OSBuild          string   `json:"os_build" xml:"os_build,omitempty"`
+	SIPStatus        string   `json:"sip_status" xml:"sip_status,omitempty"`
+	GatekeeperStatus string   `json:"gatekeeper_status" xml:"gatekeeper_status,omitempty"`
+	XProtectVersion  string   `json:"xprotect_version" xml:"xprotect_version,omitempty"`
+	FilevaultUsers   []string `json:"filevault2_users" xml:"filevault2_users,omitempty"`
 }
 
 // CertificateInformation holds information about certs intalled on the device

--- a/classic/computer_extension_attr.go
+++ b/classic/computer_extension_attr.go
@@ -20,7 +20,7 @@ import (
 func (j *Client) ComputerExtensionAttrExists(identifier interface{}) bool {
 	_, err := j.ComputerExtensionAttributeDetails(identifier)
 	if err != nil {
-		if !strings.Contains(err.Error(), "The server has not found anything matching the request URI") {
+		if !strings.Contains(err.Error(), "the server has not found anything matching the request URI") {
 			j.logger.Errorf("did not find computer extension attribute %v due to %s", identifier, err.Error())
 		}
 		return false
@@ -102,11 +102,11 @@ func (j *Client) CreateComputerExtensionAttribute(content *ComputerExtensionAttr
 	}
 
 	if content == nil {
-		return nil, errors.Wrapf(fmt.Errorf("Empty payload"), "unable to process JAMF creation request for computer extension attribute: (%s)", ep)
+		return nil, errors.Wrapf(fmt.Errorf("empty payload"), "unable to process JAMF creation request for computer extension attribute: (%s)", ep)
 	}
 
 	if content.Name == "" {
-		return nil, errors.Wrapf(fmt.Errorf("Name required for new computer extension attribute"), "unable to process JAMF creation request for computer extension attribute: (%s)", ep)
+		return nil, errors.Wrapf(fmt.Errorf("name required for new computer extension attribute"), "unable to process JAMF creation request for computer extension attribute: (%s)", ep)
 	}
 
 	err = ValidateComputerExtensionAttribute(content)

--- a/classic/computer_extension_attr_test.go
+++ b/classic/computer_extension_attr_test.go
@@ -174,7 +174,7 @@ func TestCreateComputerExtAttr(t *testing.T) {
 	newCompExtAttr := &jamf.ComputerExtensionAttribute{}
 	_, err = j.CreateComputerExtensionAttribute(newCompExtAttr)
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "Name required for new computer extension attribute")
+	assert.Contains(t, err.Error(), "name required for new computer extension attribute")
 
 	newCompExtAttr = &jamf.ComputerExtensionAttribute{
 		Name:        "Testing Ext Attr",

--- a/classic/computer_test.go
+++ b/classic/computer_test.go
@@ -161,7 +161,7 @@ func computerResponseMocks(t *testing.T) *httptest.Server {
 		assert.Nil(t, err)
 	}))
 }
-func TestQueryComputer(t *testing.T) {
+func TestListComputers(t *testing.T) {
 	testServer := computerResponseMocks(t)
 	defer testServer.Close()
 	j, err := jamf.NewClient(testServer.URL, "fake-username", "mock-password-cool", nil)
@@ -220,4 +220,20 @@ func TestQuerySpecificComputer(t *testing.T) {
 	assert.Equal(t, 2, computer.Info.ConfigProfiles[0].ID)
 	assert.Equal(t, "Test Config Profile", computer.Info.ConfigProfiles[0].Name)
 	assert.Equal(t, false, computer.Info.ConfigProfiles[0].Removable)
+}
+
+func TestGetComputer(t *testing.T) {
+	testServer := computerResponseMocks(t)
+	defer testServer.Close()
+	j, err := jamf.NewClient(testServer.URL, "fake-username", "mock-password-cool", nil)
+	assert.Nil(t, err)
+
+	opts := &jamf.GetComputerOptions{
+		ID: "82",
+	}
+
+	computer, err := j.GetComputer(opts)
+	assert.Nil(t, err)
+	// General Info
+	assert.Equal(t, 82, computer.Info.General.ID)
 }

--- a/classic/computer_test.go
+++ b/classic/computer_test.go
@@ -153,6 +153,22 @@ func computerResponseMocks(t *testing.T) *httptest.Server {
 						}]
 				}
 			}`)
+		case fmt.Sprintf("%s/serialnumber/VM0L+J/0cr+l", COMPUTER_API_BASE_ENDPOINT):
+			fmt.Fprintf(w, `{
+				"computer": {
+					"general": {
+						"id": 82,
+						"name": "Test Machine (Serial Number)",
+						"mac_address": "00:00:00:A0:FE:00",
+						"serial_number": "VM0L+J/0cr+l",
+						"udid": "000DF0BF-00FF-D00B-FA00-000F0DA0FE00",
+						"jamf_version": "20.18.0-t0000000000",
+						"platform": "Mac",
+						"mdm_capable": false,
+						"report_date": "2020-09-11 23:06:00"
+					}
+				}
+			}`)
 		default:
 			http.Error(w, fmt.Sprintf("bad Jamf computer API call to %s", r.URL), http.StatusInternalServerError)
 			return
@@ -222,7 +238,7 @@ func TestQuerySpecificComputer(t *testing.T) {
 	assert.Equal(t, false, computer.Info.ConfigProfiles[0].Removable)
 }
 
-func TestGetComputer(t *testing.T) {
+func TestGetComputer__ID(t *testing.T) {
 	testServer := computerResponseMocks(t)
 	defer testServer.Close()
 	j, err := jamf.NewClient(testServer.URL, "fake-username", "mock-password-cool", nil)
@@ -236,4 +252,21 @@ func TestGetComputer(t *testing.T) {
 	assert.Nil(t, err)
 	// General Info
 	assert.Equal(t, 82, computer.Info.General.ID)
+}
+
+func TestGetComputer__SerialNumber(t *testing.T) {
+	testServer := computerResponseMocks(t)
+	defer testServer.Close()
+	j, err := jamf.NewClient(testServer.URL, "fake-username", "mock-password-cool", nil)
+	assert.Nil(t, err)
+
+	opts := &jamf.GetComputerOptions{
+		SerialNumber: "VM0L+J/0cr+l",
+	}
+
+	computer, err := j.GetComputer(opts)
+	assert.Nil(t, err)
+	// General Info
+	assert.Equal(t, 82, computer.Info.General.ID)
+	assert.Equal(t, "Test Machine (Serial Number)", computer.Info.General.Name)
 }

--- a/classic/computer_test.go
+++ b/classic/computer_test.go
@@ -3,7 +3,10 @@
 package classic_test
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -154,21 +157,40 @@ func computerResponseMocks(t *testing.T) *httptest.Server {
 				}
 			}`)
 		case fmt.Sprintf("%s/serialnumber/VM0L+J/0cr+l", COMPUTER_API_BASE_ENDPOINT):
-			fmt.Fprintf(w, `{
-				"computer": {
-					"general": {
-						"id": 82,
-						"name": "Test Machine (Serial Number)",
-						"mac_address": "00:00:00:A0:FE:00",
-						"serial_number": "VM0L+J/0cr+l",
-						"udid": "000DF0BF-00FF-D00B-FA00-000F0DA0FE00",
-						"jamf_version": "20.18.0-t0000000000",
-						"platform": "Mac",
-						"mdm_capable": false,
-						"report_date": "2020-09-11 23:06:00"
+			switch r.Method {
+			case "GET":
+				fmt.Fprintf(w, `{
+					"computer": {
+						"general": {
+							"id": 82,
+							"name": "Test Machine (Serial Number)",
+							"mac_address": "00:00:00:A0:FE:00",
+							"serial_number": "VM0L+J/0cr+l",
+							"udid": "000DF0BF-00FF-D00B-FA00-000F0DA0FE00",
+							"jamf_version": "20.18.0-t0000000000",
+							"platform": "Mac",
+							"mdm_capable": false,
+							"report_date": "2020-09-11 23:06:00"
+						}
 					}
+				}`)
+			case "PUT", "POST":
+				data, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					fmt.Fprint(w, err.Error())
 				}
-			}`)
+				contents := &jamf.ComputerDetails{}
+				err = xml.Unmarshal(data, contents)
+				if err != nil {
+					fmt.Fprint(w, err.Error())
+				}
+				resp, err := json.MarshalIndent(contents, "", "    ")
+				if err != nil {
+					fmt.Fprint(w, err.Error())
+				}
+				fmt.Fprint(w, string(resp))
+			}
+
 		default:
 			http.Error(w, fmt.Sprintf("bad Jamf computer API call to %s", r.URL), http.StatusInternalServerError)
 			return
@@ -244,11 +266,11 @@ func TestGetComputer__ID(t *testing.T) {
 	j, err := jamf.NewClient(testServer.URL, "fake-username", "mock-password-cool", nil)
 	assert.Nil(t, err)
 
-	opts := &jamf.GetComputerOptions{
+	id := &jamf.ComputerIdentifier{
 		ID: "82",
 	}
 
-	computer, err := j.GetComputer(opts)
+	computer, err := j.GetComputer(id)
 	assert.Nil(t, err)
 	// General Info
 	assert.Equal(t, 82, computer.Info.General.ID)
@@ -260,13 +282,38 @@ func TestGetComputer__SerialNumber(t *testing.T) {
 	j, err := jamf.NewClient(testServer.URL, "fake-username", "mock-password-cool", nil)
 	assert.Nil(t, err)
 
-	opts := &jamf.GetComputerOptions{
+	id := &jamf.ComputerIdentifier{
 		SerialNumber: "VM0L+J/0cr+l",
 	}
 
-	computer, err := j.GetComputer(opts)
+	computer, err := j.GetComputer(id)
 	assert.Nil(t, err)
 	// General Info
 	assert.Equal(t, 82, computer.Info.General.ID)
 	assert.Equal(t, "Test Machine (Serial Number)", computer.Info.General.Name)
+}
+
+func TestUpdateComputer__SerialNumber(t *testing.T) {
+	testServer := computerResponseMocks(t)
+	defer testServer.Close()
+	j, err := jamf.NewClient(testServer.URL, "fake-username", "mock-password-cool", nil)
+	assert.Nil(t, err)
+
+	update := &jamf.ComputerDetails{
+		General: jamf.GeneralInformation{
+			Name: "Updated_Computer",
+		},
+		UserLocation: jamf.LocationInformation{
+			EmailAddress: "test@email.com",
+		},
+	}
+
+	id := &jamf.ComputerIdentifier{
+		SerialNumber: "VM0L+J/0cr+l",
+	}
+
+	comp, err := j.UpdateComputer(id, update)
+	assert.Nil(t, err)
+	assert.Equal(t, "Updated_Computer", comp.General.Name)
+	assert.Equal(t, "test@email.com", comp.UserLocation.EmailAddress)
 }

--- a/classic/policy.go
+++ b/classic/policy.go
@@ -91,7 +91,7 @@ func (j *Client) CreatePolicy(content *PolicyContents) (*PolicyContents, error) 
 	}
 
 	if content.General.Name == "" {
-		return nil, errors.Wrapf(fmt.Errorf("Name required for new policy"), "unable to process JAMF creation request for policy: (%s)", ep)
+		return nil, errors.Wrapf(fmt.Errorf("name required for new policy"), "unable to process JAMF creation request for policy: (%s)", ep)
 	}
 
 	if len(content.Scripts) > 0 {

--- a/classic/scripts.go
+++ b/classic/scripts.go
@@ -95,11 +95,11 @@ func (j *Client) CreateScript(content *ScriptContents) (*ScriptContents, error) 
 	}
 
 	if content.Name == "" {
-		return nil, errors.Wrapf(fmt.Errorf("Name required for new script"), "unable to process JAMF creation request for script: (%s)", ep)
+		return nil, errors.Wrapf(fmt.Errorf("name required for new script"), "unable to process JAMF creation request for script: (%s)", ep)
 	}
 
 	if content.Contents == "" {
-		return nil, errors.Wrapf(fmt.Errorf("Script contents required"), "unable to process JAMF creation request for script: (%s)", ep)
+		return nil, errors.Wrapf(fmt.Errorf("script contents required"), "unable to process JAMF creation request for script: (%s)", ep)
 	}
 
 	if content.Filename == "" {

--- a/classic/scripts_test.go
+++ b/classic/scripts_test.go
@@ -183,14 +183,14 @@ func TestCreateScriptRequiredContent(t *testing.T) {
 
 	_, err = j.CreateScript(newScript)
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "Name required for new script")
+	assert.Contains(t, err.Error(), "name required for new script")
 
 	newScriptNoContent := &jamf.ScriptContents{
 		Name: "I am missing contents",
 	}
 	_, contentErr := j.CreateScript(newScriptNoContent)
 	assert.NotNil(t, contentErr)
-	assert.Contains(t, contentErr.Error(), "Script contents required")
+	assert.Contains(t, contentErr.Error(), "script contents required")
 }
 
 func TestDeleteScript(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,16 @@
 module github.com/DataDog/jamf-api-client-go
 
-go 1.13
+go 1.18
 
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20220702020025-31831981b65f // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220702020025-31831981b65f h1:xdsejrW/0Wf2diT5CPp3XmKUNbr7Xvw8kYilQ+6qjRY=
+golang.org/x/sys v0.0.0-20220702020025-31831981b65f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=


### PR DESCRIPTION
## What does this PR do?

- Adds in a backwards compatible `GetComputers` method that takes in options of supported search parameters (i.e id, name, serialnumber). `EndpointBuilder` does not accommodate serial number as an option in its current state since we assume string identifiers are for `/name/*`
- Adds in `UpdateComputer` method with unit tests
- Updates tests and go version

## PR Checklist 

- [x] The title & description contain a short meaningful summary of work completed
- [x] Tests have been updated/created and are passing locally
- [ ] Related documentation and [CHANGELOG](https://github.com/DataDog/jamf-api-client-go/blob/main/CHANGELOG.md) have been updated
- [ ] I reviewed the [contributing](https://github.com/DataDog/jamf-api-client-go/blob/main/CONTRIBUTING.md) documentation

## Related PRs or Issues

- [link](<>)
