### PR TITLE
[BUG FIX] Allow for XML nested extension attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0.beta.5
+- Adds support for XML nesting extension attributes in `ComputerDetails`
+- Renames `ExtensionAttributes` type to `ExtensionAttribute`
+- Adds XML field tags for `ExtensionAttribute`
+
 ## 1.0.0.beta.4
 - Adds support for `/classes` endpoint
 - Fixes bug in computer update response

--- a/classic/computer_entity.go
+++ b/classic/computer_entity.go
@@ -35,7 +35,7 @@ type ComputerDetails struct {
 	Hardware            HardwareInformation      `json:"hardware" xml:"-"`
 	Certificates        []CertificateInformation `json:"certificates" xml:"-"`
 	Software            SoftwareInformation      `json:"software" xml:"-"`
-	ExtensionAttributes []ExtensionAttribute     `json:"extension_attributes" xml:"extension_attributes>extension_attribute"`
+	ExtensionAttributes []ExtensionAttribute     `json:"extension_attributes" xml:"extension_attributes>extension_attribute,omitempty"`
 	Groups              GroupInformation         `json:"groups_accounts" xml:"-"`
 	ConfigProfiles      []ConfigProfile          `json:"configuration_profiles" xml:"configuration_profiles,omitempty"`
 }
@@ -103,9 +103,9 @@ type ApplicationInformation struct {
 // ExtensionAttribute holds extension attribute information for a device
 type ExtensionAttribute struct {
 	ID    int    `json:"id,omitempty" xml:"id,omitempty"`
-	Name  string `json:"name" xml:"name,omitempty"`
-	Type  string `json:"type" xml:"type,omitempty"`
-	Value string `json:"value" xml:"value,omitempty"`
+	Name  string `json:"name" xml:"name"`
+	Type  string `json:"type" xml:"type"`
+	Value string `json:"value" xml:"value"`
 }
 
 // GroupInformation holds the groups the device is a member of

--- a/classic/computer_entity.go
+++ b/classic/computer_entity.go
@@ -35,7 +35,7 @@ type ComputerDetails struct {
 	Hardware            HardwareInformation      `json:"hardware" xml:"-"`
 	Certificates        []CertificateInformation `json:"certificates" xml:"-"`
 	Software            SoftwareInformation      `json:"software" xml:"-"`
-	ExtensionAttributes []ExtensionAttributes    `json:"extension_attributes" xml:"extension_attributes,omitempty"`
+	ExtensionAttributes []ExtensionAttribute     `json:"extension_attributes" xml:"extension_attributes>extension_attribute"`
 	Groups              GroupInformation         `json:"groups_accounts" xml:"-"`
 	ConfigProfiles      []ConfigProfile          `json:"configuration_profiles" xml:"configuration_profiles,omitempty"`
 }
@@ -100,8 +100,8 @@ type ApplicationInformation struct {
 	Version string `json:"version"`
 }
 
-// ExtensionAttributes holds extension attribute information for a device
-type ExtensionAttributes struct {
+// ExtensionAttribute holds extension attribute information for a device
+type ExtensionAttribute struct {
 	ID    int    `json:"id,omitempty" xml:"id,omitempty"`
 	Name  string `json:"name" xml:"name,omitempty"`
 	Type  string `json:"type" xml:"type,omitempty"`

--- a/classic/computer_entity.go
+++ b/classic/computer_entity.go
@@ -102,10 +102,10 @@ type ApplicationInformation struct {
 
 // ExtensionAttributes holds extension attribute information for a device
 type ExtensionAttributes struct {
-	ID    int    `json:"id,omitempty"`
-	Name  string `json:"name"`
-	Type  string `json:"type"`
-	Value string `json:"value"`
+	ID    int    `json:"id,omitempty" xml:"id,omitempty"`
+	Name  string `json:"name" xml:"name,omitempty"`
+	Type  string `json:"type" xml:"type,omitempty"`
+	Value string `json:"value" xml:"value,omitempty"`
 }
 
 // GroupInformation holds the groups the device is a member of


### PR DESCRIPTION
## What does this PR do?

Previously, extension attributes were not being rendered correctly in XML, which was preventing updates to extension attributes from being successful when included in the `UpdateComputer` function. 

This PR:
- Adds support for XML nesting extension attributes in `ComputerDetails`
- Renames `ExtensionAttributes` type to `ExtensionAttribute`
- Adds XML field tags for `ExtensionAttribute`

**Testing**

Existing tests parsing a JSON response with extension attributes still pass.

I functionally tested using the following code (sensitive info subbed) and was able to see the extension attributes updated in JAMF:
```
package main

import (
	"github.com/DataDog/jamf-api-client-go/classic"
)

func main() {
	s, _ := classic.NewClient("DOMAIN", "USERNAME", "PASSWORD", nil)
	update := &classic.ComputerDetails{
		UserLocation: classic.LocationInformation{
			EmailAddress: "EMAIL ADDRESS",
			Department:   "Engineering",
		},
		ExtensionAttributes: []classic.ExtensionAttribute{
			{
				Name:  "Date Given To User (YYYY-MM-DD)",
				Type:  "Date",
				Value: "2022-12-31",
			},
			{
				Name:  "Location",
				Type:  "String",
				Value: "Boston",
			},
		},
	}

	serial := classic.ComputerIdentifier{
		SerialNumber: "FAKESERIAL",
	}

	_, _ = s.UpdateComputer(&serial, update)
}

```

The XML in the payload: 
```
<computer>
	<general></general>
	<location>
		<email_address>EMAIL ADDRESS</email_address>
		<department>Engineering</department>
	</location>
	<extension_attributes>
		<extension_attribute>
			<name>Date Given To User (YYYY-MM-DD)</name>
			<type>Date</type>
			<value>2022-12-31</value>
		</extension_attribute>
		<extension_attribute>
			<name>Location</name>
			<type>String</type>
			<value>Boston</value>
		</extension_attribute>
	</extension_attributes>
</computer>
```

I also tested these changes in https://github.com/DataDog/corpit-lambdas/pull/1864

## PR Checklist 

- [X] The title & description contain a short meaningful summary of work completed
- [X] Tests have been updated/created and are passing locally
- [X] Related documentation and [CHANGELOG](https://github.com/DataDog/jamf-api-client-go/blob/main/CHANGELOG.md) have been updated
- [X] I reviewed the [contributing](https://github.com/DataDog/jamf-api-client-go/blob/main/CONTRIBUTING.md) documentation

## Related PRs or Issues

- [link](<>)
