### PR TITLE
[FEATURE] Add support for managing computer groups

### DIFF
--- a/classic/client.go
+++ b/classic/client.go
@@ -24,6 +24,7 @@ const (
 	policiesContext        = "policies"
 	scriptsContext         = "scripts"
 	maxAuthAttempts        = 3
+	computerGroupsContext  = "computergroups"
 )
 
 // Client represents the interface used to communicate with

--- a/classic/client.go
+++ b/classic/client.go
@@ -20,11 +20,11 @@ import (
 const (
 	classesContext         = "classes"
 	computersContext       = "computers"
+	computerGroupsContext  = "computergroups"
 	computerExtAttrContext = "computerextensionattributes"
 	policiesContext        = "policies"
 	scriptsContext         = "scripts"
 	maxAuthAttempts        = 3
-	computerGroupsContext  = "computergroups"
 )
 
 // Client represents the interface used to communicate with

--- a/classic/computer_entity.go
+++ b/classic/computer_entity.go
@@ -10,13 +10,6 @@ type Computers struct {
 	List []BasicComputerInfo `json:"computers"`
 }
 
-// ComputerGroup represents a group a device is a member of in Jamf
-type ComputerGroup struct {
-	ID      int    `json:"id,omitempty" xml:"id,omitempty"`
-	Name    string `json:"name" xml:"name"`
-	IsSmart bool   `json:"is_smart" xml:"is_smart,omitempty"`
-}
-
 // BasicComputerInfo represents the information returned in a list of all computers from Jamf
 type BasicComputerInfo struct {
 	GeneralInformation

--- a/classic/computer_group.go
+++ b/classic/computer_group.go
@@ -10,67 +10,60 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (j *Client) Groups() ([]BasicComputerGroupInformation, error) {
+// ComputerGroups represents a list of computer groups in Jamf
+func (j *Client) ComputerGroups() ([]BasicComputerGroupInfo, error) {
 	ep := fmt.Sprintf("%s/%s", j.Endpoint, computerGroupsContext)
 	req, err := http.NewRequestWithContext(context.Background(), "GET", ep, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error building Jamf computer groups query request")
 	}
-	res := Groups{}
+	res := ComputerGroups{}
 	if err := j.makeAPIrequest(req, &res); err != nil {
 		return nil, errors.Wrapf(err, "unable to query available computer groups from %s", ep)
 	}
 	return res.List, nil
 }
 
-// GroupDetails returns the details for a specific group given its ID or Name
-func (j *Client) GroupDetails(identifier interface{}) (*ComputerGroupDetails, error) {
+// ComputerGroupDetails returns the details for a specific group given its ID or Name
+func (j *Client) ComputerGroupDetails(identifier any) (*ComputerGroup, error) {
 	ep, err := EndpointBuilder(j.Endpoint, computerGroupsContext, identifier)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error building JAMF query request endpoint for group: %v", identifier)
+		return nil, errors.Wrapf(err, "error building JAMF query request endpoint for computer group: %v", identifier)
 	}
 
 	req, err := http.NewRequestWithContext(context.Background(), "GET", ep, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error building JAMF query request for group: %v", identifier)
+		return nil, errors.Wrapf(err, "error building JAMF query request for computer group: %v", identifier)
 	}
 
-	res := ComputerGroupDetails{}
+	res := ComputerGroup{}
 	if err := j.makeAPIrequest(req, &res); err != nil {
-		return nil, errors.Wrapf(err, "unable to query group with ID: %d from %s", identifier, ep)
+		return nil, errors.Wrapf(err, "unable to query computer group with ID: %d from %s", identifier, ep)
 	}
 	return &res, nil
 }
 
-// UpdateComputerGroupMemebers will update the members of a computer group in Jamf by either group ID or group Name
-func (j *Client) UpdateComputerGroupMemebers(identifier interface{}, add, remove *[]GeneralInformation) (*ComputerGroupDetails, error) {
+// UpdateComputerGroupMembers will update the members of a computer group in Jamf by either group ID or group Name
+func (j *Client) UpdateComputerGroupMembers(identifier any, updates *ComputerGroupBindingChanges) (*ComputerGroupDetails, error) {
 	ep, err := EndpointBuilder(j.Endpoint, computerGroupsContext, identifier)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error building JAMF query request for group: %v", identifier)
+		return nil, errors.Wrapf(err, "error building JAMF query request for computer group: %v", identifier)
 	}
 
-	type computer_group struct {
-		Additions *[]GeneralInformation `xml:"computer_additions>computer"`
-		Removals  *[]GeneralInformation `xml:"computer_deletions>computer"`
-	}
-	grp := computer_group{
-		Additions: add,
-		Removals:  remove,
-	}
-	bodyContent, err := xml.MarshalIndent(grp, "", "    ")
+	bodyContent, err := xml.Marshal(updates)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error building JAMF update payload for group: %v", identifier)
+		return nil, errors.Wrapf(err, "error building JAMF update payload for computer group: %v", identifier)
 	}
 
 	body := bytes.NewReader(bodyContent)
 	req, err := http.NewRequestWithContext(context.Background(), "PUT", ep, body)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error building JAMF update request for group: %v (%s)", identifier, ep)
+		return nil, errors.Wrapf(err, "error building JAMF update request for computer group: %v (%s)", identifier, ep)
 	}
-	fmt.Println(string(bodyContent))
+
 	res := ComputerGroupDetails{}
 	if err := j.makeAPIrequest(req, &res); err != nil {
-		return nil, errors.Wrapf(err, "unable to process JAMF update request for group: %v (%s)", identifier, ep)
+		return nil, errors.Wrapf(err, "unable to process JAMF update request for computer group: %v (%s)", identifier, ep)
 	}
 
 	return &res, nil

--- a/classic/computer_group.go
+++ b/classic/computer_group.go
@@ -1,0 +1,77 @@
+package classic
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+func (j *Client) Groups() ([]BasicComputerGroupInformation, error) {
+	ep := fmt.Sprintf("%s/%s", j.Endpoint, computerGroupsContext)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", ep, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error building Jamf computer groups query request")
+	}
+	res := Groups{}
+	if err := j.makeAPIrequest(req, &res); err != nil {
+		return nil, errors.Wrapf(err, "unable to query available computer groups from %s", ep)
+	}
+	return res.List, nil
+}
+
+// GroupDetails returns the details for a specific group given its ID or Name
+func (j *Client) GroupDetails(identifier interface{}) (*ComputerGroupDetails, error) {
+	ep, err := EndpointBuilder(j.Endpoint, computerGroupsContext, identifier)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF query request endpoint for group: %v", identifier)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", ep, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF query request for group: %v", identifier)
+	}
+
+	res := ComputerGroupDetails{}
+	if err := j.makeAPIrequest(req, &res); err != nil {
+		return nil, errors.Wrapf(err, "unable to query group with ID: %d from %s", identifier, ep)
+	}
+	return &res, nil
+}
+
+// UpdateComputerGroupMemebers will update the members of a computer group in Jamf by either group ID or group Name
+func (j *Client) UpdateComputerGroupMemebers(identifier interface{}, add, remove *[]GeneralInformation) (*ComputerGroupDetails, error) {
+	ep, err := EndpointBuilder(j.Endpoint, computerGroupsContext, identifier)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF query request for group: %v", identifier)
+	}
+
+	type computer_group struct {
+		Additions *[]GeneralInformation `xml:"computer_additions>computer"`
+		Removals  *[]GeneralInformation `xml:"computer_deletions>computer"`
+	}
+	grp := computer_group{
+		Additions: add,
+		Removals:  remove,
+	}
+	bodyContent, err := xml.MarshalIndent(grp, "", "    ")
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF update payload for group: %v", identifier)
+	}
+
+	body := bytes.NewReader(bodyContent)
+	req, err := http.NewRequestWithContext(context.Background(), "PUT", ep, body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF update request for group: %v (%s)", identifier, ep)
+	}
+	fmt.Println(string(bodyContent))
+	res := ComputerGroupDetails{}
+	if err := j.makeAPIrequest(req, &res); err != nil {
+		return nil, errors.Wrapf(err, "unable to process JAMF update request for group: %v (%s)", identifier, ep)
+	}
+
+	return &res, nil
+}

--- a/classic/computer_group.go
+++ b/classic/computer_group.go
@@ -68,3 +68,50 @@ func (j *Client) UpdateComputerGroupMembers(identifier any, updates *ComputerGro
 
 	return &res, nil
 }
+
+func (j *Client) CreateComputerGroup(newGroup *ComputerGroupDetails) (*ComputerGroupDetails, error) {
+	ep, err := EndpointBuilder(j.Endpoint, computerGroupsContext, -1)
+	if err != nil {
+		return nil, errors.Wrap(err, "error building JAMF add computer group request endpoint")
+	}
+
+	if newGroup.Name == "" {
+		return nil, errors.New("error building JAMF add computer group request: group name is required")
+	}
+
+	bodyContent, err := xml.MarshalIndent(newGroup, "", "    ")
+	if err != nil {
+		return nil, errors.Wrap(err, "error building JAMF add computer group payload")
+	}
+
+	body := bytes.NewReader(bodyContent)
+	req, err := http.NewRequestWithContext(context.Background(), "POST", ep, body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF add computer group request")
+	}
+
+	res := ComputerGroupDetails{}
+	if err := j.makeAPIrequest(req, &res); err != nil {
+		return nil, errors.Wrap(err, "unable to process JAMF add computer group request")
+	}
+
+	return &res, nil
+}
+
+func (j *Client) DeleteComputerGroup(identifier any) (*ComputerGroupDetails, error) {
+	ep, err := EndpointBuilder(j.Endpoint, computerGroupsContext, identifier)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF delete computer group request endpoint for group: %v", identifier)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "DELETE", ep, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error building JAMF delete computer group request for group: %v", identifier)
+	}
+	res := ComputerGroupDetails{}
+	if err := j.makeAPIrequest(req, &res); err != nil {
+		return nil, errors.Wrapf(err, "unable to process JAMF delete computer group request for group: %v", identifier)
+	}
+
+	return &res, nil
+}

--- a/classic/computer_group.go
+++ b/classic/computer_group.go
@@ -79,7 +79,7 @@ func (j *Client) CreateComputerGroup(newGroup *ComputerGroupDetails) (*ComputerG
 		return nil, errors.New("error building JAMF add computer group request: group name is required")
 	}
 
-	bodyContent, err := xml.MarshalIndent(newGroup, "", "    ")
+	bodyContent, err := xml.Marshal(newGroup)
 	if err != nil {
 		return nil, errors.Wrap(err, "error building JAMF add computer group payload")
 	}
@@ -108,6 +108,7 @@ func (j *Client) DeleteComputerGroup(identifier any) (*ComputerGroupDetails, err
 	if err != nil {
 		return nil, errors.Wrapf(err, "error building JAMF delete computer group request for group: %v", identifier)
 	}
+
 	res := ComputerGroupDetails{}
 	if err := j.makeAPIrequest(req, &res); err != nil {
 		return nil, errors.Wrapf(err, "unable to process JAMF delete computer group request for group: %v", identifier)

--- a/classic/computer_group_entity.go
+++ b/classic/computer_group_entity.go
@@ -17,11 +17,12 @@ type ComputerGroup struct {
 type BasicComputerGroupInfo struct {
 	ID      int    `json:"id,omitempty" xml:"id,omitempty"`
 	Name    string `json:"name,omitempty" xml:"name"`
-	IsSmart bool   `json:"is_smart" xml:"is_smart,omitempty"`
+	IsSmart bool   `json:"is_smart" xml:"is_smart"`
 }
 
 // ComputerGroupDetails represents the detailed information for a specific computer group
 type ComputerGroupDetails struct {
+	XMLName xml.Name `json:"computer_group" xml:"computer_group,omitempty"`
 	BasicComputerGroupInfo
 	Computers []BasicComputerInfo `json:"computers" xml:"computers>computer,omitempty"`
 }

--- a/classic/computer_group_entity.go
+++ b/classic/computer_group_entity.go
@@ -1,21 +1,35 @@
 package classic
 
-type Groups struct {
-	List []BasicComputerGroupInformation `json:"computer_groups" xml:"computer_groups>computer_group,omitempty"`
+import "encoding/xml"
+
+type ComputerGroups struct {
+	List []BasicComputerGroupInfo `json:"computer_groups" xml:"computer_groups>computer_group,omitempty"`
+	Size int                      `json:"size" xml:"size"`
 }
 
-// BasicComputerGroupInformation holds the basic information for all groups in Jamf
-type BasicComputerGroupInformation struct {
-	GeneralGroupInformation
+// ComputerGroup represents a group a device is a member of in Jamf
+type ComputerGroup struct {
+	Info ComputerGroupDetails `json:"computer_group" xml:"computer_group,omitempty"`
 }
-type GeneralGroupInformation struct {
+
+// BasicComputerGroupInfo represents the information returned in a list of all
+// computer groups from Jamf
+type BasicComputerGroupInfo struct {
 	ID      int    `json:"id,omitempty" xml:"id,omitempty"`
-	Name    string `json:"name" xml:"name,omitempty"`
+	Name    string `json:"name,omitempty" xml:"name"`
 	IsSmart bool   `json:"is_smart" xml:"is_smart,omitempty"`
 }
+
+// ComputerGroupDetails represents the detailed information for a specific computer group
 type ComputerGroupDetails struct {
-	ID        int                 `json:"id,omitempty" xml:"id,omitempty"`
-	Name      string              `json:"name" xml:"name"`
-	IsSmart   bool                `json:"is_smart" xml:"is_smart,omitempty"`
+	BasicComputerGroupInfo
 	Computers []BasicComputerInfo `json:"computers" xml:"computers>computer,omitempty"`
+}
+
+// ComputerGroupBindingChanges represents the changes to a computer group binding when
+// updating the members of a computer group in Jamf
+type ComputerGroupBindingChanges struct {
+	XMLName   xml.Name             `json:"-" xml:"computer_group,omitempty"`
+	Additions []GeneralInformation `xml:"computer_additions>computer"`
+	Removals  []GeneralInformation `xml:"computer_deletions>computer"`
 }

--- a/classic/computer_group_entity.go
+++ b/classic/computer_group_entity.go
@@ -1,0 +1,21 @@
+package classic
+
+type Groups struct {
+	List []BasicComputerGroupInformation `json:"computer_groups" xml:"computer_groups>computer_group,omitempty"`
+}
+
+// BasicComputerGroupInformation holds the basic information for all groups in Jamf
+type BasicComputerGroupInformation struct {
+	GeneralGroupInformation
+}
+type GeneralGroupInformation struct {
+	ID      int    `json:"id,omitempty" xml:"id,omitempty"`
+	Name    string `json:"name" xml:"name,omitempty"`
+	IsSmart bool   `json:"is_smart" xml:"is_smart,omitempty"`
+}
+type ComputerGroupDetails struct {
+	ID        int                 `json:"id,omitempty" xml:"id,omitempty"`
+	Name      string              `json:"name" xml:"name"`
+	IsSmart   bool                `json:"is_smart" xml:"is_smart,omitempty"`
+	Computers []BasicComputerInfo `json:"computers" xml:"computers>computer,omitempty"`
+}

--- a/classic/computer_group_test.go
+++ b/classic/computer_group_test.go
@@ -36,7 +36,7 @@ func computerGroupsResponseMocks(t *testing.T) *httptest.Server {
 							"is_smart": false
 					}]
 				}`)
-		case fmt.Sprintf("%s/id/1", COMPUTER_GROUPS_BASE_API_ENDPOINT), fmt.Sprintf("%s/id/-1", COMPUTER_GROUPS_BASE_API_ENDPOINT), fmt.Sprintf("%s/name/Test%sGroup%s1", COMPUTER_GROUPS_BASE_API_ENDPOINT, "%20", "%20"):
+		case fmt.Sprintf("%s/id/1", COMPUTER_GROUPS_BASE_API_ENDPOINT), fmt.Sprintf("%s/name/Test%sGroup%s1", COMPUTER_GROUPS_BASE_API_ENDPOINT, "%20", "%20"):
 			switch r.Method {
 			case "GET":
 				w.Header().Add("Content-Type", "application/xml")
@@ -72,7 +72,7 @@ func computerGroupsResponseMocks(t *testing.T) *httptest.Server {
 	}))
 }
 
-func TestListAllGroups(t *testing.T) {
+func TestListAllComputerGroups(t *testing.T) {
 	server := computerGroupsResponseMocks(t)
 	defer server.Close()
 	j, err := jamf.NewClient(server.URL, "test", "test", server.Client(), jamf.WithTokenAuth())
@@ -91,7 +91,7 @@ func TestListAllGroups(t *testing.T) {
 	assert.Equal(t, false, grps[2].IsSmart)
 }
 
-func TestQuerySpecificGroups(t *testing.T) {
+func TestQuerySpecificComputerGroups(t *testing.T) {
 	server := computerGroupsResponseMocks(t)
 	defer server.Close()
 	j, err := jamf.NewClient(server.URL, "test", "test", server.Client(), jamf.WithTokenAuth())

--- a/classic/computer_group_test.go
+++ b/classic/computer_group_test.go
@@ -3,6 +3,7 @@ package classic_test
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -36,23 +37,61 @@ func computerGroupsResponseMocks(t *testing.T) *httptest.Server {
 							"is_smart": false
 					}]
 				}`)
-		case fmt.Sprintf("%s/id/1", COMPUTER_GROUPS_BASE_API_ENDPOINT), fmt.Sprintf("%s/name/Test%sGroup%s1", COMPUTER_GROUPS_BASE_API_ENDPOINT, "%20", "%20"):
+		case fmt.Sprintf("%s/id/1", COMPUTER_GROUPS_BASE_API_ENDPOINT), fmt.Sprintf("%s/id/-1", COMPUTER_GROUPS_BASE_API_ENDPOINT), fmt.Sprintf("%s/name/Test%sGroup%s1", COMPUTER_GROUPS_BASE_API_ENDPOINT, "%20", "%20"):
 			switch r.Method {
 			case "GET":
 				w.Header().Add("Content-Type", "application/xml")
 				mockGroup := &jamf.ComputerGroup{
-					jamf.ComputerGroupDetails{
-						jamf.BasicComputerGroupInfo{
+					Info: jamf.ComputerGroupDetails{
+						BasicComputerGroupInfo: jamf.BasicComputerGroupInfo{
 							ID:      1,
 							Name:    "Test Group 1",
 							IsSmart: false,
 						},
-						[]jamf.BasicComputerInfo{
+						Computers: []jamf.BasicComputerInfo{
 							{
 								GeneralInformation: jamf.GeneralInformation{
 									ID:   1,
 									Name: "Test Computer 1",
 								},
+							},
+						},
+					},
+				}
+				groupData, err := xml.MarshalIndent(mockGroup, "", "  ")
+				if err != nil {
+					fmt.Fprintf(w, err.Error())
+				}
+				fmt.Fprintf(w, string(groupData))
+			case "POST":
+				w.Header().Add("Content-Type", "application/xml")
+				data, err := io.ReadAll(r.Body)
+				if err != nil {
+					fmt.Fprintf(w, err.Error())
+				}
+				groupContents := &jamf.ComputerGroupDetails{}
+				err = xml.Unmarshal(data, groupContents)
+				if err != nil {
+					fmt.Fprintf(w, err.Error())
+				}
+				groupData, err := xml.MarshalIndent(groupContents, "", "  ")
+				if err != nil {
+					fmt.Fprintf(w, err.Error())
+				}
+				fmt.Fprintf(w, string(groupData))
+			default:
+				w.Header().Add("Content-Type", "application/xml")
+				mockGroup := &jamf.ComputerGroupDetails{
+					BasicComputerGroupInfo: jamf.BasicComputerGroupInfo{
+						ID:      1,
+						Name:    "Test Group 1",
+						IsSmart: false,
+					},
+					Computers: []jamf.BasicComputerInfo{
+						{
+							GeneralInformation: jamf.GeneralInformation{
+								ID:   1,
+								Name: "Test Computer 1",
 							},
 						},
 					},
@@ -103,4 +142,41 @@ func TestQuerySpecificComputerGroups(t *testing.T) {
 	assert.Equal(t, false, grp.Info.IsSmart)
 	assert.Equal(t, 1, grp.Info.Computers[0].ID)
 	assert.Equal(t, "Test Computer 1", grp.Info.Computers[0].Name)
+}
+
+func TestCreateComputerGroup(t *testing.T) {
+	server := computerGroupsResponseMocks(t)
+	defer server.Close()
+	j, err := jamf.NewClient(server.URL, "test", "test", server.Client(), jamf.WithTokenAuth())
+	assert.Nil(t, err)
+	grp := &jamf.ComputerGroupDetails{
+		BasicComputerGroupInfo: jamf.BasicComputerGroupInfo{
+			Name:    "Unit Test Group",
+			IsSmart: false,
+		},
+		Computers: []jamf.BasicComputerInfo{},
+	}
+	createdGrp, err := j.CreateComputerGroup(grp)
+	assert.Nil(t, err)
+	assert.Equal(t, "Unit Test Group", createdGrp.Name)
+	assert.Equal(t, false, createdGrp.IsSmart)
+	assert.Equal(t, 0, len(createdGrp.Computers))
+}
+
+func TestDeleteComputerGroup(t *testing.T) {
+	server := computerGroupsResponseMocks(t)
+	defer server.Close()
+	j, err := jamf.NewClient(server.URL, "test", "test", server.Client(), jamf.WithTokenAuth())
+	assert.Nil(t, err)
+	deletedGrp, err := j.DeleteComputerGroup(1)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, deletedGrp.ID)
+	assert.Equal(t, "Test Group 1", deletedGrp.Name)
+	assert.Equal(t, false, deletedGrp.IsSmart)
+
+	deletedGrp, err = j.DeleteComputerGroup("Test%20Group%201")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, deletedGrp.ID)
+	assert.Equal(t, "Test Group 1", deletedGrp.Name)
+	assert.Equal(t, false, deletedGrp.IsSmart)
 }

--- a/classic/computer_group_test.go
+++ b/classic/computer_group_test.go
@@ -1,0 +1,106 @@
+package classic_test
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	jamf "github.com/DataDog/jamf-api-client-go/classic"
+	"github.com/stretchr/testify/assert"
+)
+
+var COMPUTER_GROUPS_BASE_API_ENDPOINT = "/JSSResource/computergroups"
+
+func computerGroupsResponseMocks(t *testing.T) *httptest.Server {
+	var resp string
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.RequestURI {
+		case COMPUTER_GROUPS_BASE_API_ENDPOINT:
+			fmt.Fprintf(w, `{
+				"computer_groups": [
+					{
+							"id": 1,
+							"name": "Test Group 1",
+							"is_smart": false
+					},
+					{
+							"id": 2,
+							"name": "Test Group 2",
+							"is_smart": true
+					},
+					{
+							"id": 3,
+							"name": "Test Group 3",
+							"is_smart": false
+					}]
+				}`)
+		case fmt.Sprintf("%s/id/1", COMPUTER_GROUPS_BASE_API_ENDPOINT), fmt.Sprintf("%s/id/-1", COMPUTER_GROUPS_BASE_API_ENDPOINT), fmt.Sprintf("%s/name/Test%sGroup%s1", COMPUTER_GROUPS_BASE_API_ENDPOINT, "%20", "%20"):
+			switch r.Method {
+			case "GET":
+				w.Header().Add("Content-Type", "application/xml")
+				mockGroup := &jamf.ComputerGroup{
+					jamf.ComputerGroupDetails{
+						jamf.BasicComputerGroupInfo{
+							ID:      1,
+							Name:    "Test Group 1",
+							IsSmart: false,
+						},
+						[]jamf.BasicComputerInfo{
+							{
+								GeneralInformation: jamf.GeneralInformation{
+									ID:   1,
+									Name: "Test Computer 1",
+								},
+							},
+						},
+					},
+				}
+				groupData, err := xml.MarshalIndent(mockGroup, "", "  ")
+				if err != nil {
+					fmt.Fprintf(w, err.Error())
+				}
+				fmt.Fprintf(w, string(groupData))
+			}
+		default:
+			http.Error(w, fmt.Sprintf("bad Jamf API %s call to %s", r.Method, r.URL), http.StatusInternalServerError)
+			return
+		}
+		_, err := w.Write([]byte(resp))
+		assert.Nil(t, err)
+	}))
+}
+
+func TestListAllGroups(t *testing.T) {
+	server := computerGroupsResponseMocks(t)
+	defer server.Close()
+	j, err := jamf.NewClient(server.URL, "test", "test", server.Client(), jamf.WithTokenAuth())
+	assert.Nil(t, err)
+	grps, err := j.ComputerGroups()
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(grps))
+	assert.Equal(t, 1, grps[0].ID)
+	assert.Equal(t, "Test Group 1", grps[0].Name)
+	assert.Equal(t, false, grps[0].IsSmart)
+	assert.Equal(t, 2, grps[1].ID)
+	assert.Equal(t, "Test Group 2", grps[1].Name)
+	assert.Equal(t, true, grps[1].IsSmart)
+	assert.Equal(t, 3, grps[2].ID)
+	assert.Equal(t, "Test Group 3", grps[2].Name)
+	assert.Equal(t, false, grps[2].IsSmart)
+}
+
+func TestQuerySpecificGroups(t *testing.T) {
+	server := computerGroupsResponseMocks(t)
+	defer server.Close()
+	j, err := jamf.NewClient(server.URL, "test", "test", server.Client(), jamf.WithTokenAuth())
+	assert.Nil(t, err)
+	grp, err := j.ComputerGroupDetails(1)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, grp.Info.ID)
+	assert.Equal(t, "Test Group 1", grp.Info.Name)
+	assert.Equal(t, false, grp.Info.IsSmart)
+	assert.Equal(t, 1, grp.Info.Computers[0].ID)
+	assert.Equal(t, "Test Computer 1", grp.Info.Computers[0].Name)
+}

--- a/classic/policy_test.go
+++ b/classic/policy_test.go
@@ -138,7 +138,7 @@ func TestUpdatePolicy(t *testing.T) {
 			Name: "Test Policy",
 		},
 		Scope: &jamf.Scope{
-			ComputerGroups: []*jamf.ComputerGroup{
+			ComputerGroups: []*jamf.BasicComputerGroupInfo{
 				{
 					Name: "Test Smart Group",
 				},

--- a/classic/scope_entity.go
+++ b/classic/scope_entity.go
@@ -5,14 +5,14 @@ package classic
 
 // Scope represents the scope of a related Jamf configuration setting or Policy
 type Scope struct {
-	AllComputers   bool                  `json:"all_computers" xml:"all_computers,omitempty"`
-	Computers      []*BasicComputerInfo  `json:"computers" xml:"computers>computer,omitempty"`
-	ComputerGroups []*ComputerGroup      `json:"computer_groups" xml:"computer_groups>computer_group,omitempty"`
-	Buildings      []*Building           `json:"buildings" xml:"buildings,omitempty"`
-	Departments    []*Department         `json:"departments" xml:"departments,omitempty"`
-	LimitToUsers   *UserGroupLimitations `json:"limit_to_users" xml:"limit_to_users,omitempty"`
-	Limitations    *Limitations          `json:"limitations" xml:"limitations,omitempty"`
-	Exclusions     *Exclusions           `json:"exclusions" xml:"exclusions,omitempty"`
+	AllComputers   bool                      `json:"all_computers" xml:"all_computers,omitempty"`
+	Computers      []*BasicComputerInfo      `json:"computers" xml:"computers>computer,omitempty"`
+	ComputerGroups []*BasicComputerGroupInfo `json:"computer_groups" xml:"computer_groups>computer_group,omitempty"`
+	Buildings      []*Building               `json:"buildings" xml:"buildings,omitempty"`
+	Departments    []*Department             `json:"departments" xml:"departments,omitempty"`
+	LimitToUsers   *UserGroupLimitations     `json:"limit_to_users" xml:"limit_to_users,omitempty"`
+	Limitations    *Limitations              `json:"limitations" xml:"limitations,omitempty"`
+	Exclusions     *Exclusions               `json:"exclusions" xml:"exclusions,omitempty"`
 }
 
 // Building represents a building configured in Jamf that a setting can be scoped to

--- a/docs/api_coverage.md
+++ b/docs/api_coverage.md
@@ -19,7 +19,7 @@
     - [x] Update computer by [ID](https://developer.jamf.com/jamf-pro/reference/updatecomputerbyid) or [Name](https://developer.jamf.com/jamf-pro/reference/updatecomputerbyname)
 
   - `/computerGroups`
-    - [x] [Create a new computer group](https://developer.jamf.com/jamf-pro/reference/findcomputergroups)
+    - [x] [Create a new computer group](https://developer.jamf.com/jamf-pro/reference/createcomputergroupbyid)
     - [x] Delete specific computer group by [ID](https://developer.jamf.com/jamf-pro/reference/deletecomputergroupbyid) or [first computer group by Name](https://developer.jamf.com/jamf-pro/reference/deletecomputergroupbyname)
     - [x] [Get all computer groups](https://developer.jamf.com/jamf-pro/reference/findcomputergroups)
     - [x] Update computer group members by [ID](https://developer.jamf.com/jamf-pro/reference/updatecomputergroupbyid) or [Name](https://developer.jamf.com/jamf-pro/reference/updatecomputergroupbyname)

--- a/docs/api_coverage.md
+++ b/docs/api_coverage.md
@@ -14,9 +14,15 @@
     - [x] Delete computer extension attribute by [ID](https://developer.jamf.com/jamf-pro/reference/deletecomputerextensionattributebyid) or [Name](https://developer.jamf.com/jamf-pro/reference/deletecomputerextensionattributebyname)
 
   - `/computers`
-    - [x] [Get all computers](https://developer.jamf.com/jamf-pro/reference/findcomputers)
+    - [x] [Get all computers](https://developer.jamf.com/jamf-pro/reference/createcomputergroupbyid)
     - [x] Get specific computer by [ID](https://developer.jamf.com/jamf-pro/reference/findcomputersbyid) or [first computer by Name](https://developer.jamf.com/jamf-pro/reference/findcomputersbyname)
     - [x] Update computer by [ID](https://developer.jamf.com/jamf-pro/reference/updatecomputerbyid) or [Name](https://developer.jamf.com/jamf-pro/reference/updatecomputerbyname)
+
+  - `/computerGroups`
+    - [x] [Create a new computer group](https://developer.jamf.com/jamf-pro/reference/findcomputergroups)
+    - [x] Delete specific computer group by [ID](https://developer.jamf.com/jamf-pro/reference/deletecomputergroupbyid) or [first computer group by Name](https://developer.jamf.com/jamf-pro/reference/deletecomputergroupbyname)
+    - [x] [Get all computer groups](https://developer.jamf.com/jamf-pro/reference/findcomputergroups)
+    - [x] Update computer group members by [ID](https://developer.jamf.com/jamf-pro/reference/updatecomputergroupbyid) or [Name](https://developer.jamf.com/jamf-pro/reference/updatecomputergroupbyname)
 
   - `/osxconfigurationprofiles` **(In Progress)**
     - [ ] [Get all configuration profiles](https://developer.jamf.com/jamf-pro/reference/findosxconfigurationprofiles)

--- a/docs/api_coverage.md
+++ b/docs/api_coverage.md
@@ -14,7 +14,7 @@
     - [x] Delete computer extension attribute by [ID](https://developer.jamf.com/jamf-pro/reference/deletecomputerextensionattributebyid) or [Name](https://developer.jamf.com/jamf-pro/reference/deletecomputerextensionattributebyname)
 
   - `/computers`
-    - [x] [Get all computers](https://developer.jamf.com/jamf-pro/reference/createcomputergroupbyid)
+    - [x] [Get all computers](https://developer.jamf.com/jamf-pro/reference/findcomputers)
     - [x] Get specific computer by [ID](https://developer.jamf.com/jamf-pro/reference/findcomputersbyid) or [first computer by Name](https://developer.jamf.com/jamf-pro/reference/findcomputersbyname)
     - [x] Update computer by [ID](https://developer.jamf.com/jamf-pro/reference/updatecomputerbyid) or [Name](https://developer.jamf.com/jamf-pro/reference/updatecomputerbyname)
 


### PR DESCRIPTION
## What does this PR do?
Adds support for interacting with the `/computergroups` endpoints.

`REQUIRED` A few sentences describing the overall goals of the pull request's commits.

To add the ability to manage groups. Includes create, delete and update members.

## PR Checklist 

- [x] The title & description contain a short meaningful summary of work completed
- [x] Tests have been updated/created and are passing locally
- [x] Related documentation and [CHANGELOG](https://github.com/DataDog/jamf-api-client-go/blob/main/CHANGELOG.md) have been updated
- [x] I reviewed the [contributing](https://github.com/DataDog/jamf-api-client-go/blob/main/CONTRIBUTING.md) documentation

## Related PRs or Issues

`N/A`