### PR TITLE
[EENG-6683] Unify Enterprise Engineering team tag

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # and another the rest of the directory.
 
 # All your base
-*                                         @DataDog/corp-it-eng
+*                                         @DataDog/enterprise-engineering


### PR DESCRIPTION
Unifies old Corp IT / Enterprise Engineering team slugs (`corp-it-eng`, `corpit-eng`, `enterprise-eng-platform`, `enterprise-eng-integrations`) to the single `enterprise-engineering` team slug in CODEOWNERS. Paths and unrelated team mentions are unchanged.